### PR TITLE
XIVY-623 Use 'ivy' as goal prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@
         <configuration>
           <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          <goalPrefix>ivy</goalPrefix>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/ch/ivyteam/ivy/maven/IarDeployMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/IarDeployMojo.java
@@ -37,7 +37,7 @@ import ch.ivyteam.ivy.maven.engine.deploy.dir.IvyDeployer;
  * -Divy.deploy.engine.app=Portal</pre>
  * 
  * @since 6.1.0
- * @deprecated since 7.1.0. Use the {@link DeployToEngineMojo#GOAL} instead.
+ * @deprecated since 7.1.0. Use the deploy-to-engine goal instead.
  */
 @Deprecated
 @Mojo(name = IarDeployMojo.GOAL, requiresProject=false)


### PR DESCRIPTION
- you can now use ivy:deploy-to-engine instead of
project-build:deploy-to-engine or even worse
com.axonivy.ivy.ci:project-build-plugin:7.4.0:deploy-to-engine