### PR TITLE
Explicitly set project encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <other.site.name>Stable</other.site.name>
     <other.site.path>release</other.site.path>
     <autoRelease>true</autoRelease>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <profiles>


### PR DESCRIPTION
avoid platform dependent build, set project encoding to UTF-8.

see #10

If you don't want like an explicit encoding configuration or want another encoding, just close this PR / issue =)