### PR TITLE
Add IntellJ idea project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 # Maven
 /log/
 /target/
+
+# Idea
+*.iml
+.idea/


### PR DESCRIPTION
For external contributors using intellij idea it would be great to have the idea
project files in the .gitignore file too.

No issue for that PR.