### PR TITLE
XIVY-2927 Upgrade to newest zip4j lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>net.lingala.zip4j</groupId>
       <artifactId>zip4j</artifactId>
-      <version>1.2.3</version>
+      <version>2.1.2</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/src/main/java/ch/ivyteam/ivy/maven/InstallEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/InstallEngineMojo.java
@@ -41,7 +41,7 @@ import ch.ivyteam.ivy.maven.engine.EngineVersionEvaluator;
 import ch.ivyteam.ivy.maven.engine.download.EngineDownloader;
 import ch.ivyteam.ivy.maven.engine.download.MavenEngineDownloader;
 import ch.ivyteam.ivy.maven.engine.download.URLEngineDownloader;
-import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 
 /**

--- a/src/test/java/ch/ivyteam/ivy/maven/TestInstallEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestInstallEngineMojo.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory.OsgiDir;
 import ch.ivyteam.ivy.maven.engine.EngineVersionEvaluator;
 import ch.ivyteam.ivy.maven.engine.download.URLEngineDownloader;
-import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.model.ZipParameters;
 
@@ -110,7 +110,7 @@ public class TestInstallEngineMojo
     File zipDir = createFakeEngineDir(ivyVersion);
     File zipFile = new File(zipDir, "fake.zip");
     ZipFile zip = new ZipFile(zipFile);
-    zip.createZipFileFromFolder(new File(zipDir, OsgiDir.INSTALL_AREA), new ZipParameters(), false, 0);
+    zip.createSplitZipFileFromFolder(new File(zipDir, OsgiDir.INSTALL_AREA), new ZipParameters(), false, 0);
     return zipFile;
   }
 


### PR DESCRIPTION
- the newest version correctly preservers file permissions when
unpacking zips. this is at least for elasticsearch/bin (x-flag)
- nice side effect. also axon ivy engine launchers /bin has now correct
file permissions (x-flag)