### PR TITLE
XIVY-3334 build with java11

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -14,8 +14,9 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="src/site"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
+			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </organization>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <maven.version>3.2.3</maven.version>
     <!-- version should match ivy Engine sfl4j version! And version in EngineClassLoaderFactory.SLF4J_VERSION -->
     <slf4j.version>1.7.25</slf4j.version>
@@ -223,20 +223,20 @@
   </dependencies>
 
   <build>
+  
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>
         <!-- Makes MOJO declaration trough Annotation possible. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.6.0</version>
         <configuration>
           <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -255,7 +255,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.10</version>
+        <version>3.0.0-M3</version>
         <configuration>
           <excludes>
             <exclude>base/**/*</exclude>
@@ -266,7 +266,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -289,7 +289,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -304,7 +304,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.1.1</version>
         <configuration>
-          <source>8</source>
+          <release>${java.version}</release>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
+          <version>3.8.2</version>
           <executions>
             <execution>
               <id>default-deploy</id><!-- use github pages instead! -->
@@ -452,13 +453,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.6.0</version>
         <configuration>
           <requirements>
             <others>
               <property>
                 <name>ivy engine</name>
-                <value>6.1</value>
+                <value>8.0</value>
               </property>
             </others>
           </requirements>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -39,7 +39,7 @@ under the License.
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.4</version>
+    <version>1.8</version>
   </skin>
   
   <custom>


### PR DESCRIPTION
- simplify maintenance and and streamline the plugin to use the same JDK
as the ivy-core platform
- update maven plugins to be compatible with java 11

BUILD: https://zugprojenkins/job/project-build-plugin/job/feature%252FXIVY-3371-projectBuildPlugin-j11/