### PR TITLE
XIVY-3384 state used engine as info log

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/InstallEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/InstallEngineMojo.java
@@ -135,6 +135,7 @@ public class InstallEngineMojo extends AbstractEngineMojo
   {
     getLog().info("Provide engine for ivy version " + ivyVersion);
     ensureEngineIsInstalled();
+    getLog().info("Using engine in '"+getRawEngineDirectory()+"'");
   }
 
   private void ensureEngineIsInstalled() throws MojoExecutionException


### PR DESCRIPTION
- ease error cause detection by printing the engine dir.

BUILDS: https://zugprojenkins/job/project-build-plugin/job/feature%252FXIVY-3384-exposeUsedEngine/