### PR TITLE
Simplify release process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,94 +13,41 @@ pipeline {
   }
 
   parameters {
-    booleanParam(name: 'skipGitHubSite',
+    booleanParam(
+      name: 'skipGitHubSite',
       description: 'If checked the plugin documentation on GitHub will NOT be updated (ignored for release)',
-      defaultValue: true)
+      defaultValue: true
+    )
 
-    choice(name: 'engineListUrl',
+    choice(
+      name: 'engineListUrl',
       description: 'Engine to use for build',
       choices: ['http://zugprojenkins/job/ivy-core_product/job/master/lastSuccessfulBuild/',
-                'http://zugprobldmas/job/Trunk_All/lastSuccessfulBuild/'])
-
-    choice(name: 'deployProfile',
-      description: 'Choose where the built plugin should be deployed to',
-      choices: ['zugpronexus.snapshots', 'sonatype.snapshots', 'maven.central.release'])
-
-    string(name: 'nextDevVersion',
-      description: "Next development version used after release, e.g. '7.3.0' (no '-SNAPSHOT').\nNote: This is only used for release target; if not set next patch version will be raised by one",
-      defaultValue: '' )
+                'http://zugprobldmas/job/Trunk_All/lastSuccessfulBuild/']
+    )
   }
 
   stages {
-    stage('snapshot build') {
-      when {
-        expression { params.deployProfile != 'maven.central.release' }
-      }
+    stage('build') {      
       steps {
         script {
           setupGPGEnvironment()
           withCredentials([string(credentialsId: 'gpg.password', variable: 'GPG_PWD')]) {
-
-            maven cmd: "clean deploy site-deploy " +
-              "-P ${params.deployProfile} " +
+            maven cmd: "clean deploy site-deploy " +              
               "-Dgpg.project-build.password='${env.GPG_PWD}' " +
               "-Dgpg.skip=false " +
               "-Dgithub.site.skip=${params.skipGitHubSite} " +
-              "-Divy.engine.list.url=${params.engineListUrl} " +
-              "-Dmaven.test.failure.ignore=true"
-
+              "-Divy.engine.list.url=${params.engineListUrl} "
           }
-          maven cmd: "sonar:sonar -Dsonar.host.url=http://zugprosonar"
-        }
-        archiveArtifacts 'target/*.jar'
-        junit '**/target/surefire-reports/**/*.xml'
-      }
-    }
-    
-    stage('release build') {
-      when {
-        branch 'master'
-        expression { params.deployProfile == 'maven.central.release' }
-      }
-      steps {
-
-        script {
-          def nextDevVersionParam = createNextDevVersionJVMParam()
-          setupGPGEnvironment()
-          sh "git config --global user.name 'ivy-team'"
-          sh "git config --global user.email 'nobody@axonivy.com'"
-          
-          withCredentials([string(credentialsId: 'gpg.password', variable: 'GPG_PWD')]) {
-
-            withEnv(['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']) {
-              sshagent(credentials: ['github-axonivy']) {
-                maven cmd: "clean verify release:prepare release:perform " +
-                  "-P ${params.deployProfile} " +
-                  "${nextDevVersionParam} " +
-                  "-Dgpg.project-build.password='${env.GPG_PWD}' " +
-                  "-Dgpg.skip=false " +
-                  "-Dmaven.test.skip=true " +
-                  "-Darguments=-Divy.engine.list.url=${params.engineListUrl} "
-              }
-            }
+          if (env.BRANCH_NAME == 'master') {
+            maven cmd: "sonar:sonar -Dsonar.host.url=http://zugprosonar"
           }
         }
         archiveArtifacts 'target/*.jar'
         junit '**/target/surefire-reports/**/*.xml'
       }
-    }
+    }   
   }
-}
-
-def createNextDevVersionJVMParam() {
-  def nextDevelopmentVersion = '' 
-  if (params.nextDevVersion.trim() =~ /\d+\.\d+\.\d+/) {
-    echo "nextDevVersion is set to ${params.nextDevVersion.trim()}"
-    nextDevelopmentVersion = "-DdevelopmentVersion=${params.nextDevVersion.trim()}-SNAPSHOT"
-  } else {
-    echo "nextDevVersion is NOT set or does not match version pattern - using default"
-  }
-  return nextDevelopmentVersion
 }
 
 def setupGPGEnvironment() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,17 +13,16 @@ pipeline {
   }
 
   parameters {
-    booleanParam(
+    booleanParam (
       name: 'skipGitHubSite',
       description: 'If checked the plugin documentation on GitHub will NOT be updated (ignored for release)',
       defaultValue: true
     )
 
-    choice(
+    string (
       name: 'engineListUrl',
       description: 'Engine to use for build',
-      choices: ['http://zugprojenkins/job/ivy-core_product/job/master/lastSuccessfulBuild/',
-                'http://zugprobldmas/job/Trunk_All/lastSuccessfulBuild/']
+      defaultValue: 'http://zugprojenkins/job/ivy-core_product/job/master/lastSuccessfulBuild/'
     )
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,20 +3,23 @@
   <groupId>com.axonivy.ivy.ci</groupId>
   <artifactId>project-build-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>8.0.0-SNAPSHOT</version>
+  <version>7.4.0-SNAPSHOT</version>
 
   <name>Axon.ivy Project Build Plugin</name>
   <description>Maven plugin for the automated building of Axon.ivy projects. Referenced from the pom.xml of Axon.ivy projects.</description>
   <url>https://github.com/axonivy/project-build-plugin</url>
+
   <prerequisites>
     <maven>3.1</maven>
   </prerequisites>
+
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
+
   <developers>
     <developer>
       <name>Axon.ivy Project Build Authors</name>
@@ -30,7 +33,6 @@
     <connection>scm:git:git@github.com:axonivy/project-build-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:axonivy/project-build-plugin.git</developerConnection>
     <url>git@github.com:axonivy/project-build-plugin.git</url>
-    <tag>v7.2.0</tag>
   </scm>
 
   <organization>
@@ -43,65 +45,30 @@
     <maven.version>3.2.3</maven.version>
     <!-- version should match ivy Engine sfl4j version! And version in EngineClassLoaderFactory.SLF4J_VERSION -->
     <slf4j.version>1.7.25</slf4j.version>
-    <site.path>snapshot</site.path>
-    <other.site.name>Stable</other.site.name>
-    <other.site.path>release</other.site.path>
     <autoRelease>true</autoRelease>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+
+    <site.path>release</site.path>
+    <other.site.name>Snapshot</other.site.name>
+    <other.site.path>snapshot</other.site.path>
+    <run.public.download.test>true</run.public.download.test>
+
+    <maven.test.failure.ignore>true</maven.test.failure.ignore>
   </properties>
 
-  <profiles>
-    <profile>
-      <id>zugpronexus.snapshots</id>
-      <distributionManagement>
-        <snapshotRepository>
-          <id>zugpronexus.snapshots</id>
-          <name>Internal Plugin Snapshot Repository</name>
-          <url>http://zugpronexus:8081/nexus/content/repositories/build-plugin-snapshots/</url>
-        </snapshotRepository>
-      </distributionManagement>
-    </profile>
-    <profile>
+  <distributionManagement>
+    <repository>
+      <id>sonatype.releases</id>
+      <name>Sonatype Releases Repo</name>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
+    </repository>
+    <snapshotRepository>
       <id>sonatype.snapshots</id>
-      <distributionManagement>
-        <snapshotRepository>
-          <id>sonatype.snapshots</id>
-          <name>Maven Central Snapshots Repo</name>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
-    </profile>
-    <profile>
-      <id>maven.central.release</id>
-      <distributionManagement>
-        <repository>
-          <id>sonatype.releases</id>
-          <name>Sonatype Releases Repo</name>
-          <url>https://oss.sonatype.org/content/repositories/releases/</url>
-        </repository>
-      </distributionManagement>
-      <properties>
-        <site.path>release</site.path>
-        <other.site.name>Snapshot</other.site.name>
-        <other.site.path>snapshot</other.site.path>
-        <run.public.download.test>true</run.public.download.test>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-release-plugin</artifactId>
-            <version>2.5.3</version>
-            <configuration>
-              <tagNameFormat>v@{project.version}</tagNameFormat>
-              <releaseProfiles>release</releaseProfiles>
-              <goals>deploy site-deploy</goals>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+      <name>Maven Central Snapshots Repo</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <dependencies>
     <dependency>
@@ -219,11 +186,9 @@
       <version>1.3.0</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>
-  
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -232,6 +197,7 @@
           <release>${java.version}</release>
         </configuration>
       </plugin>
+
       <plugin>
         <!-- Makes MOJO declaration trough Annotation possible. -->
         <groupId>org.apache.maven.plugins</groupId>
@@ -253,6 +219,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M3</version>
@@ -263,6 +230,7 @@
           <argLine>-Dskip.public.download.test=${skip.public.download.test}</argLine>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
@@ -286,6 +254,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
@@ -299,6 +268,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -315,6 +285,7 @@
           </execution>
         </executions>
       </plugin>
+  
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -330,6 +301,7 @@
           </execution>
         </executions>
       </plugin>
+    
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <version>1.8</version>
@@ -351,17 +323,19 @@
           </execution>
         </executions>
       </plugin>
+  
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <version>1.6.6</version>
         <extensions>true</extensions>
         <configuration>
-		  <serverId>sonatype.snapshots</serverId>
+          <serverId>sonatype.snapshots</serverId>
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
           <autoReleaseAfterClose>${autoRelease}</autoReleaseAfterClose>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>com.github.github</groupId>
         <artifactId>site-maven-plugin</artifactId>
@@ -376,6 +350,7 @@
               <path>${site.path}/${pluginVersion.majorVersion}.${pluginVersion.minorVersion}</path>
             </configuration>
           </execution>
+
           <execution>
             <id>deploy.site.redirect.to.github</id>
             <goals><goal>site</goal></goals>
@@ -432,6 +407,7 @@
             </lifecycleMappingMetadata>
           </configuration>
         </plugin>
+
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.8.2</version>
@@ -465,6 +441,7 @@
           </requirements>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>


### PR DESCRIPTION
Hello @ivy-arus @ivy-rew 

The `pom.xml` and `Jenkinsfile` of such an simple maven project is really complicated.

This here is a work in progress, with major changes:
- only deploy SNAPSHOT releases to SONATYPE. do not deploy snapshot releases to our nexus artifactory anymore. It is complicated in this build here and why we should have to targets for this?
- get rid of maven-release-plugin. in the maven community this is a 'deprecated' thing. a new release looks now like this.
1. remove '-SNAPSHOT' & commit & push
2. trigger build
3. increase version and add '-SNAPSHOT' & commit & push
