### PR TITLE
XIVY-3138 allow users to enable JDT warnings

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
@@ -144,7 +144,7 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineMojo
     return builder;
   }
 
-  private EngineClassLoaderFactory getEngineClassloaderFactory()
+  public final EngineClassLoaderFactory getEngineClassloaderFactory()
   {
     MavenContext context = new EngineClassLoaderFactory.MavenContext(
             repository, localRepository, project, getLog());

--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
@@ -38,6 +38,7 @@ import org.apache.maven.repository.RepositorySystem;
 import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory;
 import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory.MavenContext;
 import ch.ivyteam.ivy.maven.engine.MavenProjectBuilderProxy;
+import ch.ivyteam.ivy.maven.engine.MavenProjectBuilderProxy.Options;
 import ch.ivyteam.ivy.maven.engine.Slf4jSimpleEngineProperties;
 
 public abstract class AbstractProjectCompileMojo extends AbstractEngineMojo
@@ -65,6 +66,25 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineMojo
    */
   @Parameter(property="ivy.compiler.warnings.enabled", defaultValue = "false")
   private boolean compilerWarnings;
+
+  /** 
+   * Properties file to configure JDT compiler severities (info/warn/error).
+   * A valid properties file can be created using the Axon.ivy Designer:
+   * <ol>
+   *    <li>Open the 'Package Explorer': Windows > Show View > Other > Package Explorer</li>
+   *    <li>In Package Explorer: right click on an IvyProject > Properties</li>
+   *    <li>Navigate to Java > Compiler > Errors/Warnings</li>
+   *    <li>Enable project specific settings</li>
+   *    <li>Configure objects to analyze and it's report severity</li>
+   *    <li>Apply and close preferences dialog afterwards</li>
+   *    <li>Now the settings are persisted in '.settings/org.eclipse.jdt.prefs' of the project</li>
+   *    <li>Copy the org.eclipse.jdt.prefs to a location of your choice and pass it's path to this property</li>
+   * </ol>
+   * 
+   * @since 8.1.0
+   */
+  @Parameter(property="ivy.compiler.properties.file")
+  private File compilerProperties;
 
   /** 
    * Defines the timeout how long to wait for an engine start to compile.
@@ -134,10 +154,14 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineMojo
   protected Map<String, String> getOptions()
   {
     Map<String, String> options = new HashMap<>();
-    options.put(MavenProjectBuilderProxy.Options.TEST_SOURCE_DIR, project.getBuild().getTestSourceDirectory());
-    options.put(MavenProjectBuilderProxy.Options.COMPILE_CLASSPATH, getDependencyClasspath());
-    options.put(MavenProjectBuilderProxy.Options.SOURCE_ENCODING, encoding);
-    options.put(MavenProjectBuilderProxy.Options.WARNINGS_ENABLED, String.valueOf(compilerWarnings));
+    options.put(Options.TEST_SOURCE_DIR, project.getBuild().getTestSourceDirectory());
+    options.put(Options.COMPILE_CLASSPATH, getDependencyClasspath());
+    options.put(Options.SOURCE_ENCODING, encoding);
+    options.put(Options.WARNINGS_ENABLED, String.valueOf(compilerWarnings));
+    if (compilerProperties != null)
+    {
+      options.put(Options.SEVERITY_PROPERTIES, compilerProperties.getPath());
+    }
     return options;
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
@@ -60,6 +60,13 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineMojo
   private String encoding;
 
   /** 
+   * Logs warnings found by the compiler.
+   * @since 8.1.0
+   */
+  @Parameter(property="ivy.compiler.warnings.enabled", defaultValue = "false")
+  private boolean compilerWarnings;
+
+  /** 
    * Defines the timeout how long to wait for an engine start to compile.
    * @since 7.4.0
    */
@@ -130,6 +137,7 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineMojo
     options.put(MavenProjectBuilderProxy.Options.TEST_SOURCE_DIR, project.getBuild().getTestSourceDirectory());
     options.put(MavenProjectBuilderProxy.Options.COMPILE_CLASSPATH, getDependencyClasspath());
     options.put(MavenProjectBuilderProxy.Options.SOURCE_ENCODING, encoding);
+    options.put(MavenProjectBuilderProxy.Options.WARNINGS_ENABLED, String.valueOf(compilerWarnings));
     return options;
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
@@ -77,15 +77,21 @@ public class EngineClassLoaderFactory
     List<File> osgiClasspath = getOsgiBootstrapClasspath(engineDirectory);
     addToClassPath(osgiClasspath, new File(engineDirectory, OsgiDir.PLUGINS),
             new WildcardFileFilter("org.eclipse.osgi_*.jar"));
-    osgiClasspath.add(0, maven.getJar("org.slf4j", "slf4j-api", SLF4J_VERSION));
-    osgiClasspath.add(0, maven.getJar("org.slf4j", "slf4j-simple", SLF4J_VERSION));
-    osgiClasspath.add(0, maven.getJar("org.slf4j", "log4j-over-slf4j", SLF4J_VERSION));
+    getSlf4jJars().forEach(slf4j -> osgiClasspath.add(0, slf4j));
     if (maven.log.isDebugEnabled())
     {
       maven.log.debug("Configuring OSGi engine classpath:");
       osgiClasspath.stream().forEach(file -> maven.log.debug(" + "+file.getAbsolutePath()));
     }
     return new URLClassLoader(toUrls(osgiClasspath));
+  }
+  
+  public List<File> getSlf4jJars()
+  {
+    return List.of(
+      maven.getJar("org.slf4j", "slf4j-api", SLF4J_VERSION),
+      maven.getJar("org.slf4j", "slf4j-simple", SLF4J_VERSION),
+      maven.getJar("org.slf4j", "log4j-over-slf4j", SLF4J_VERSION));
   }
 
   public static List<File> getOsgiBootstrapClasspath(File engineDirectory)

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/MavenProjectBuilderProxy.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/MavenProjectBuilderProxy.java
@@ -176,7 +176,9 @@ public class MavenProjectBuilderProxy
     String TEST_SOURCE_DIR = "project.build.testSourceDirectory";
     String COMPILE_CLASSPATH = "maven.dependency.classpath";
     String SOURCE_ENCODING = "project.source.encoding";
+    
     String WARNINGS_ENABLED = "jdt.warnings.enabled";
+    String SEVERITY_PROPERTIES = "jdt.severity.properties";
   }
   
   public static interface Result

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/MavenProjectBuilderProxy.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/MavenProjectBuilderProxy.java
@@ -176,6 +176,7 @@ public class MavenProjectBuilderProxy
     String TEST_SOURCE_DIR = "project.build.testSourceDirectory";
     String COMPILE_CLASSPATH = "maven.dependency.classpath";
     String SOURCE_ENCODING = "project.source.encoding";
+    String WARNINGS_ENABLED = "jdt.warnings.enabled";
   }
   
   public static interface Result

--- a/src/test/java/ch/ivyteam/ivy/maven/TestLoggerIntegration.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestLoggerIntegration.java
@@ -1,0 +1,52 @@
+package ch.ivyteam.ivy.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory;
+
+public class TestLoggerIntegration extends BaseEngineProjectMojoTest
+{
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  
+  @Before
+  public void setup()
+  {
+    System.setOut(new PrintStream(outContent));
+  }
+  
+  @After
+  public void restoreStreams() {
+      System.setOut(originalOut);
+  }
+
+  
+  @Rule
+  public CompileMojoRule<CompileProjectMojo> compile = new CompileMojoRule<>(CompileProjectMojo.GOAL);
+
+  /**
+   * regression test for accidentially broken SLF4J dependencies.
+   */
+  @Test
+  public void forwardEngineLogsToMavenConsole()
+  {
+    EngineClassLoaderFactory engineClassLoader = compile.getMojo().getEngineClassloaderFactory();
+    List<File> slf4jJars = engineClassLoader.getSlf4jJars();
+    assertThat(slf4jJars).hasSize(3);
+    assertThat(slf4jJars.get(0).getName()).startsWith("slf4j-api-");
+    assertThat(outContent.toString())
+      .as("no warnings must be printed during slf4j library re-solving from local repo")
+      .isEmpty();
+  }
+  
+}


### PR DESCRIPTION
- warn logs from JDT can easily be interpreted by a CI/CD pipeline to
expose poor code within your projects

Target is the 8.1.0-SNAPSHOT release. So no influence on the upcoming 8.0.0 LTS