### PR TITLE
Bugfix/xivy 3441 forward engine logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.axonivy.ivy.ci</groupId>
   <artifactId>project-build-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>8.0.0</version>
+  <version>8.0.1-SNAPSHOT</version>
 
   <name>Axon.ivy Project Build Plugin</name>
   <description>Maven plugin for the automated building of Axon.ivy projects. Referenced from the pom.xml of Axon.ivy projects.</description>

--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
@@ -117,7 +117,7 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineMojo
     return builder;
   }
 
-  private EngineClassLoaderFactory getEngineClassloaderFactory()
+  public final EngineClassLoaderFactory getEngineClassloaderFactory()
   {
     MavenContext context = new EngineClassLoaderFactory.MavenContext(
             repository, localRepository, project, getLog());

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
@@ -77,7 +77,7 @@ public class EngineClassLoaderFactory
     List<File> osgiClasspath = getOsgiBootstrapClasspath(engineDirectory);
     addToClassPath(osgiClasspath, new File(engineDirectory, OsgiDir.PLUGINS),
             new WildcardFileFilter("org.eclipse.osgi_*.jar"));
-    getSlf4jJars().forEach(slf4j -> osgiClasspath.add(0, slf4j));
+    osgiClasspath.addAll(0, getSlf4jJars());
     if (maven.log.isDebugEnabled())
     {
       maven.log.debug("Configuring OSGi engine classpath:");

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
@@ -56,7 +56,7 @@ public class EngineClassLoaderFactory
   }
   
   /** must match version in pom.xml */
-  private static final String SLF4J_VERSION = "1.7.7";
+  private static final String SLF4J_VERSION = "1.7.25";
   
   private static final List<String> ENGINE_LIB_DIRECTORIES = Arrays.asList(
           OsgiDir.INSTALL_AREA + "/" + OsgiDir.LIB_BOOT,
@@ -77,15 +77,21 @@ public class EngineClassLoaderFactory
     List<File> osgiClasspath = getOsgiBootstrapClasspath(engineDirectory);
     addToClassPath(osgiClasspath, new File(engineDirectory, OsgiDir.PLUGINS),
             new WildcardFileFilter("org.eclipse.osgi_*.jar"));
-    osgiClasspath.add(0, maven.getJar("org.slf4j", "slf4j-api", SLF4J_VERSION));
-    osgiClasspath.add(0, maven.getJar("org.slf4j", "slf4j-simple", SLF4J_VERSION));
-    osgiClasspath.add(0, maven.getJar("org.slf4j", "log4j-over-slf4j", SLF4J_VERSION));
+    getSlf4jJars().forEach(slf4j -> osgiClasspath.add(0, slf4j));
     if (maven.log.isDebugEnabled())
     {
       maven.log.debug("Configuring OSGi engine classpath:");
       osgiClasspath.stream().forEach(file -> maven.log.debug(" + "+file.getAbsolutePath()));
     }
     return new URLClassLoader(toUrls(osgiClasspath));
+  }
+  
+  public List<File> getSlf4jJars()
+  {
+    return List.of(
+      maven.getJar("org.slf4j", "slf4j-api", SLF4J_VERSION),
+      maven.getJar("org.slf4j", "slf4j-simple", SLF4J_VERSION),
+      maven.getJar("org.slf4j", "log4j-over-slf4j", SLF4J_VERSION));
   }
 
   public static List<File> getOsgiBootstrapClasspath(File engineDirectory)

--- a/src/test/java/ch/ivyteam/ivy/maven/TestLoggerIntegration.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestLoggerIntegration.java
@@ -1,0 +1,52 @@
+package ch.ivyteam.ivy.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory;
+
+public class TestLoggerIntegration extends BaseEngineProjectMojoTest
+{
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  
+  @Before
+  public void setup()
+  {
+    System.setOut(new PrintStream(outContent));
+  }
+  
+  @After
+  public void restoreStreams() {
+      System.setOut(originalOut);
+  }
+
+  
+  @Rule
+  public CompileMojoRule<CompileProjectMojo> compile = new CompileMojoRule<>(CompileProjectMojo.GOAL);
+
+  /**
+   * regression test for accidentially broken SLF4J dependencies.
+   */
+  @Test
+  public void forwardEngineLogsToMavenConsole()
+  {
+    EngineClassLoaderFactory engineClassLoader = compile.getMojo().getEngineClassloaderFactory();
+    List<File> slf4jJars = engineClassLoader.getSlf4jJars();
+    assertThat(slf4jJars).hasSize(3);
+    assertThat(slf4jJars.get(0).getName()).startsWith("slf4j-api-");
+    assertThat(outContent.toString())
+      .as("no warnings must be printed during slf4j library re-solving from local repo")
+      .isEmpty();
+  }
+  
+}


### PR DESCRIPTION
build: http://zugprojenkins/job/project-build-plugin/job/bugfix%252FXIVY-3441-forward-engine-logs/
... the build now quickly blames differing slf4j libs as seen here: 
http://zugprojenkins/job/project-build-plugin/job/feature%252FXIVY-3138-compilerWarnings/11/testReport/ch.ivyteam.ivy.maven/TestLoggerIntegration/forwardEngineLogsToMavenConsole/