### PR TITLE
XIVY-3479 make the definition of a deployApp mandatory

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/DeployToEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/DeployToEngineMojo.java
@@ -80,7 +80,7 @@ public class DeployToEngineMojo extends AbstractEngineMojo
   File deployEngineDirectory;
   
   /** The name of an ivy application to which the file is deployed. */
-  @Parameter(property="ivy.deploy.engine.app", defaultValue="SYSTEM")
+  @Parameter(property="ivy.deploy.engine.app", required = true)
   String deployToEngineApplication;
   
   /** The auto deployment directory of the engine. Must match the ivy engine system property 'deployment.directory' */


### PR DESCRIPTION
- SYSTEM is a bad default which only leads to confusion, nobody should
use the system app for custom workflows (ivy.core) can change the system
app behaviour at any time.
- fail if parameter is not set via standard maven plugin mechanism