### PR TITLE
Never deploy to internal artifactory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 
     choice(name: 'deployProfile',
       description: 'Choose where the built plugin should be deployed to',
-      choices: ['zugpronexus.snapshots', 'sonatype.snapshots', 'maven.central.release'])
+      choices: ['sonatype.snapshots', 'maven.central.release'])
 
     string(name: 'nextDevVersion',
       description: "Next development version used after release, e.g. '7.3.0' (no '-SNAPSHOT').\nNote: This is only used for release target; if not set next patch version will be raised by one",

--- a/pom.xml
+++ b/pom.xml
@@ -50,17 +50,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <profiles>
-    <profile>
-      <id>zugpronexus.snapshots</id>
-      <distributionManagement>
-        <snapshotRepository>
-          <id>zugpronexus.snapshots</id>
-          <name>Internal Plugin Snapshot Repository</name>
-          <url>http://zugpronexus:8081/nexus/content/repositories/build-plugin-snapshots/</url>
-        </snapshotRepository>
-      </distributionManagement>
-    </profile>
+  <profiles>    
     <profile>
       <id>sonatype.snapshots</id>
       <distributionManagement>


### PR DESCRIPTION
Already start to not deploy this to our internal artifactory.
No build should faiil at the moment. But as soon as we are going to increase the version in the projects to the next SNAPSHOT version, they will fail.
In this case we have to add sonatype snapshot repository.
We will do that on demand.