### PR TITLE
XIVY-3441 fix: slf4j version mismatch disables engine logs

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractProjectCompileMojo.java
@@ -117,7 +117,7 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineMojo
     return builder;
   }
 
-  private EngineClassLoaderFactory getEngineClassloaderFactory()
+  public final EngineClassLoaderFactory getEngineClassloaderFactory()
   {
     MavenContext context = new EngineClassLoaderFactory.MavenContext(
             repository, localRepository, project, getLog());

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
@@ -56,7 +56,7 @@ public class EngineClassLoaderFactory
   }
   
   /** must match version in pom.xml */
-  private static final String SLF4J_VERSION = "1.7.7";
+  private static final String SLF4J_VERSION = "1.7.25";
   
   private static final List<String> ENGINE_LIB_DIRECTORIES = Arrays.asList(
           OsgiDir.INSTALL_AREA + "/" + OsgiDir.LIB_BOOT,
@@ -77,15 +77,21 @@ public class EngineClassLoaderFactory
     List<File> osgiClasspath = getOsgiBootstrapClasspath(engineDirectory);
     addToClassPath(osgiClasspath, new File(engineDirectory, OsgiDir.PLUGINS),
             new WildcardFileFilter("org.eclipse.osgi_*.jar"));
-    osgiClasspath.add(0, maven.getJar("org.slf4j", "slf4j-api", SLF4J_VERSION));
-    osgiClasspath.add(0, maven.getJar("org.slf4j", "slf4j-simple", SLF4J_VERSION));
-    osgiClasspath.add(0, maven.getJar("org.slf4j", "log4j-over-slf4j", SLF4J_VERSION));
+    osgiClasspath.addAll(0, getSlf4jJars());
     if (maven.log.isDebugEnabled())
     {
       maven.log.debug("Configuring OSGi engine classpath:");
       osgiClasspath.stream().forEach(file -> maven.log.debug(" + "+file.getAbsolutePath()));
     }
     return new URLClassLoader(toUrls(osgiClasspath));
+  }
+
+  public List<File> getSlf4jJars()
+  {
+    return List.of(
+      maven.getJar("org.slf4j", "slf4j-api", SLF4J_VERSION),
+      maven.getJar("org.slf4j", "slf4j-simple", SLF4J_VERSION),
+      maven.getJar("org.slf4j", "log4j-over-slf4j", SLF4J_VERSION));
   }
 
   public static List<File> getOsgiBootstrapClasspath(File engineDirectory)

--- a/src/test/java/ch/ivyteam/ivy/maven/TestLoggerIntegration.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestLoggerIntegration.java
@@ -1,0 +1,51 @@
+package ch.ivyteam.ivy.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory;
+
+public class TestLoggerIntegration extends BaseEngineProjectMojoTest
+{
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  
+  @Before
+  public void setup()
+  {
+    System.setOut(new PrintStream(outContent));
+  }
+  
+  @After
+  public void restoreStreams() {
+      System.setOut(originalOut);
+  }
+  
+  @Rule
+  public CompileMojoRule<CompileProjectMojo> compile = new CompileMojoRule<>(CompileProjectMojo.GOAL);
+
+  /**
+   * regression test for accidentially broken SLF4J dependencies.
+   */
+  @Test
+  public void forwardEngineLogsToMavenConsole()
+  {
+    EngineClassLoaderFactory engineClassLoader = compile.getMojo().getEngineClassloaderFactory();
+    List<File> slf4jJars = engineClassLoader.getSlf4jJars();
+    assertThat(slf4jJars).hasSize(3);
+    assertThat(slf4jJars.get(0).getName()).startsWith("slf4j-api-");
+    assertThat(outContent.toString())
+      .as("no warnings must be printed during slf4j library re-solving from local repo")
+      .isEmpty();
+  }
+  
+}


### PR DESCRIPTION
- added test that fail with log warnings 'non resolvable slf4j' which
indicate a version conflict between the resolved maven plugin
dependencies and the api used by the Axon.ivy Engine.