### PR TITLE
XIVY-3138 Define maven compiler source level for sonar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,9 @@ pipeline {
               "-Dmaven.test.failure.ignore=true"
 
           }
+          if (env.BRANCH_NAME == 'master') {
+            maven cmd: "sonar:sonar -Dsonar.host.url=https://sonar.ivyteam.io -Dsonar.projectKey=project-build-plugin -Dsonar.projectName=project-build-plugin"
+          }
         }
         archiveArtifacts 'target/*.jar'
         junit '**/target/surefire-reports/**/*.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
           setupGPGEnvironment()
           withCredentials([string(credentialsId: 'gpg.password', variable: 'GPG_PWD')]) {
 
-            def phase = env.BRANCH_NAME == '8.0' ? 'deploy site-deploy' : 'verify'
+            def phase = env.BRANCH_NAME == 'master' ? 'deploy site-deploy' : 'verify'
             maven cmd: "clean ${phase} " +
               "-P ${params.deployProfile} " +
               "-Dgpg.project-build.password='${env.GPG_PWD}' " +
@@ -58,7 +58,7 @@ pipeline {
     
     stage('release build') {
       when {
-        branch '8.0'
+        branch 'master'
         expression { params.deployProfile == 'maven.central.release' }
       }
       steps {

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,10 @@
         <version>3.8.1</version>
         <configuration>
           <release>${java.version}</release>
+
+          <!-- needed for sonar (sonar plugin is not aware of 'release') -->
+          <source>${java.version}</source>
+          <target>${java.version}</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Build: https://jenkins.ivyteam.io/job/project-build-plugin/job/feature%252FXIVY-3138-fix-master-after-renaming/

So far seems to be the only thing that got lost

- **8.0** is now the new **master**
- old **master** is now **legacy** branch (I would keep that branch alive for the time being, at least until we are sure everything works properly)