### PR TITLE
XIVY-3565 prefer local reactor projects over IAR deps

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/SetupIvyTestPropertiesMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/SetupIvyTestPropertiesMojo.java
@@ -23,8 +23,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -68,6 +71,12 @@ public class SetupIvyTestPropertiesMojo extends AbstractEngineMojo
   @Parameter(defaultValue="false", property="maven.test.skip")
   boolean skipTest;
 
+  @Parameter(defaultValue = "${localRepository}")
+  protected ArtifactRepository localRepository;
+  
+  @Component
+  private MavenSession session;
+  
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException
   {
@@ -120,7 +129,7 @@ public class SetupIvyTestPropertiesMojo extends AbstractEngineMojo
   {
     List<File> deps = new ArrayList<>();
     deps.add(project.getBasedir());
-    deps.addAll(MavenRuntime.getDependencies(project, "iar"));
+    deps.addAll(MavenRuntime.getDependencies(project, session, "iar"));
     return deps.stream()
             .map(file -> file.toURI())
             .collect(Collectors.toList());

--- a/src/main/java/ch/ivyteam/ivy/maven/util/MavenRuntime.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/util/MavenRuntime.java
@@ -6,26 +6,49 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
 public class MavenRuntime
 {
   public static List<File> getDependencies(MavenProject project, String type)
   {
-    Set<org.apache.maven.artifact.Artifact> dependencies = project.getArtifacts();
+    return getDependencies(project, null, type);
+  }
+  
+  public static List<File> getDependencies(MavenProject project, MavenSession session, String type)
+  {
+    Set<Artifact> dependencies = project.getArtifacts();
     if (dependencies == null)
     {
       return Collections.emptyList();
     }
     
     List<File> deps = new ArrayList<>();
-    for(org.apache.maven.artifact.Artifact artifact : dependencies)
+    for(Artifact artifact : dependencies)
     {
-      if (artifact.getType().equals(type))
+      MavenProject reactorProject = findReactorProject(session, artifact);
+      if (reactorProject != null && reactorProject.getArtifact().getType().equals(type))
+      {
+        deps.add(reactorProject.getBasedir());
+      }
+      else if (artifact.getType().equals(type))
       {
         deps.add(artifact.getFile());
       }
     }
     return deps;
+  }
+
+  private static MavenProject findReactorProject(MavenSession session, Artifact artifact)
+  {
+    if (session == null)
+    {
+      return null;
+    }
+    String artifactKey = artifact.getGroupId()+":"+artifact.getArtifactId()+":"+artifact.getVersion();
+    MavenProject reactorProject = session.getProjectMap().get(artifactKey);
+    return reactorProject;
   }
 }


### PR DESCRIPTION
- local projects are up to date and never dated repo artifacts
- local projects are available even when not packed: e.g. 'mvn clean
test'
- local projects (non IAR) are currently easier to deploy for
BpmExecTests.