### PR TITLE
Feature/xivy 3484 remove ivy from path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.axonivy.ivy.ci</groupId>
   <artifactId>project-build-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>9.1.0-SNAPSHOT</version>
+  <version>9.1.1-SNAPSHOT</version>
 
   <name>Axon.ivy Project Build Plugin</name>
   <description>Maven plugin for the automated building of Axon.ivy projects. Referenced from the pom.xml of Axon.ivy projects.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.axonivy.ivy.ci</groupId>
   <artifactId>project-build-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>9.1.1-SNAPSHOT</version>
+  <version>9.1.0-SNAPSHOT</version>
 
   <name>Axon.ivy Project Build Plugin</name>
   <description>Maven plugin for the automated building of Axon.ivy projects. Referenced from the pom.xml of Axon.ivy projects.</description>

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineControl.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineControl.java
@@ -198,7 +198,7 @@ public class EngineControl
     if (newLine.contains("info page of Axon.ivy Engine") && !engineStarted.get())
     {
       String url = StringUtils.substringBetween(newLine, "http://", "/");
-      url = "http://" + url + "/ivy/";
+      url = "http://" + url + "/";
       context.log.info("Axon.ivy Engine runs on : " + url);
       context.properties.setMavenProperty(Property.TEST_ENGINE_URL, url);
       engineStarted.set(true);

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineControl.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineControl.java
@@ -203,8 +203,7 @@ public class EngineControl
   {
     if (newLine.contains("info page of Axon.ivy Engine") && !engineStarted.get())
     {
-      String url = StringUtils.substringBetween(newLine, "http://", "/");
-      url = "http://" + url + "/";
+      String url = "http://" + StringUtils.substringBetween(newLine, "http://", "/") + "/";
       url += evaluateDefaultContext(url);
       context.log.info("Axon.ivy Engine runs on : " + url);
       context.properties.setMavenProperty(Property.TEST_ENGINE_URL, url);

--- a/src/test/java/ch/ivyteam/ivy/maven/TestDeployToRunningEngine.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestDeployToRunningEngine.java
@@ -31,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import ch.ivyteam.ivy.maven.DeployToEngineMojo.DeployMethod;
+import ch.ivyteam.ivy.maven.engine.EngineControl;
 
 /**
  * @since 7.1.0
@@ -58,7 +59,7 @@ public class TestDeployToRunningEngine extends BaseEngineProjectMojoTest
   
   @After
   public void restoreStreams() {
-      System.setOut(originalOut);
+    System.setOut(originalOut);
   }
 
   @Test
@@ -97,7 +98,10 @@ public class TestDeployToRunningEngine extends BaseEngineProjectMojoTest
     Executor startedProcess = null;
     try
     {
+      System.setOut(originalOut);
       startedProcess = mojo.startEngine();
+      deployMojo.deployEngineUrl = (String)rule.project.getProperties().get(EngineControl.Property.TEST_ENGINE_URL);
+      System.setOut(new PrintStream(outContent));
 
       deployMojo.execute();
       

--- a/src/test/java/ch/ivyteam/ivy/maven/TestStartEngine.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestStartEngine.java
@@ -54,7 +54,8 @@ public class TestStartEngine extends BaseEngineProjectMojoTest
     try
     {
       startedProcess = mojo.startEngine();
-      assertThat(getProperty(EngineControl.Property.TEST_ENGINE_URL)).startsWith("http://");
+      assertThat(getProperty(EngineControl.Property.TEST_ENGINE_URL)).startsWith("http://")
+              .endsWith("/ivy/");
       assertThat(new File(getProperty(EngineControl.Property.TEST_ENGINE_LOG))).exists();
     }
     finally

--- a/src/test/java/ch/ivyteam/ivy/maven/engine/TestEngineControl.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/engine/TestEngineControl.java
@@ -61,4 +61,14 @@ public class TestEngineControl extends BaseEngineProjectMojoTest
     assertThat(log.getErrors()).isEmpty();
   }
   
+  @Test
+  public void evalutateIvyContext()
+  {
+    assertThat(EngineControl.evaluateIvyContextFromUrl("sys/info.xhtml")).isEmpty();
+    assertThat(EngineControl.evaluateIvyContextFromUrl("/sys/info123.xhtml")).isEmpty();
+    assertThat(EngineControl.evaluateIvyContextFromUrl("ivy/sys/info")).isEqualTo("ivy/");
+    assertThat(EngineControl.evaluateIvyContextFromUrl("/ivy/sys/test")).isEqualTo("ivy/");
+    assertThat(EngineControl.evaluateIvyContextFromUrl("")).isEmpty();
+  }
+  
 }


### PR DESCRIPTION
Remove hardcoded "ivy/" from test.engine.url property. This will now be detected over the location (redirect) url from the first page. 
-> Support for other defaultContext (e.g nothing)

Fix "canDeployRemoteIar" test. How on earth could this test be such stable??? Test infrastructure changed port between 8080 and 8090 and this test was run only with default port 8080...


https://jenkins.ivyteam.io/job/project-build-plugin/job/feature%252FXIVY-3484_remove_ivy_from_path/
