### PR TITLE
XIVY-3449 Use proper regex expression for exclude fileset

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/IarPackagingMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/IarPackagingMojo.java
@@ -47,7 +47,7 @@ public class IarPackagingMojo extends AbstractMojo
 {
   public static final String GOAL = "pack-iar";
   private static final String[] DEFAULT_INCLUDES = new String[] {"**/*"};
-  private static final String[] DEFAULT_EXCLUDES = new String[] {"target", "%regex[target\\/(?!classes/).*]"};
+  static final String[] DEFAULT_EXCLUDES = new String[] {"target", "%regex[target/(?!classes/).*]"};
 
   @Parameter(property = "project", required = true, readonly = true)
   MavenProject project;
@@ -61,7 +61,7 @@ public class IarPackagingMojo extends AbstractMojo
    * <li>
    * <pre><code>&lt;iarExcludes&gt;
    *    &lt;iarExclude&gt;target/**&#47;*&lt;/iarExclude&gt;
-   *    &lt;iarExclude&gt;%regex[target\/(?!classes/).*]&lt;/iarExclude&gt;
+   *    &lt;iarExclude&gt;%regex[target/(?!classes/).*]&lt;/iarExclude&gt;
    *&lt;/iarExcludes&gt;</code></pre></li>
    *</ul>
    */

--- a/src/test/java/ch/ivyteam/ivy/maven/TestIarPackagingMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestIarPackagingMojo.java
@@ -32,6 +32,8 @@ import java.util.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.model.FileSet;
 import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.MatchPattern;
+import org.codehaus.plexus.util.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -197,6 +199,28 @@ public class TestIarPackagingMojo
     try (ZipFile archive = new ZipFile(iarFile))
     {
       assertThat(archive.getEntry("target")).as("'target' will not be packed when there are no target/classes").isNull();
+    }
+  }
+
+  @Test
+  public void validDefaultExcludePatternsForWindows()
+  {
+    for (var defaultExclude : IarPackagingMojo.DEFAULT_EXCLUDES)
+    {
+      defaultExclude = StringUtils.replace(defaultExclude, "/", "\\\\"); // see org.codehaus.plexus.util.AbstractScanner.normalizePattern(String)
+      var matchPattern  = MatchPattern.fromString(defaultExclude);
+      assertThat(matchPattern.matchPath("never-matching-path", false)).isFalse();
+    }
+  }
+
+  @Test
+  public void validDefaultExcludePatternsForLinux()
+  {
+    for (var defaultExclude : IarPackagingMojo.DEFAULT_EXCLUDES)
+    {
+      defaultExclude = StringUtils.replace(defaultExclude, "\\\\", "/" ); // see org.codehaus.plexus.util.AbstractScanner.normalizePattern(String)
+      var matchPattern  = MatchPattern.fromString(defaultExclude);
+      assertThat(matchPattern.matchPath("never-matching-path", false)).isFalse();
     }
   }
 }


### PR DESCRIPTION
There is no need to escape / (slashes) in a `regexp` file
pattern for maven filesets. Because there is some special
escaping by maven plexus that those regular expressions
are platform independent.