### PR TITLE
Feature/xivy 622 integration test lifecycle

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractDeployMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractDeployMojo.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2020 AXON Ivy AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.ivyteam.ivy.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.ReadOnlyFileSystemException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.MavenFileFilter;
+
+import ch.ivyteam.ivy.maven.DeployToEngineMojo.DefaultDeployOptions;
+import ch.ivyteam.ivy.maven.engine.deploy.DeploymentOptionsFileFactory;
+import ch.ivyteam.ivy.maven.engine.deploy.YamlOptionsFactory;
+import ch.ivyteam.ivy.maven.engine.deploy.dir.FileDeployer;
+import ch.ivyteam.ivy.maven.engine.deploy.dir.IvyDeployer;
+
+public abstract class AbstractDeployMojo extends AbstractIntegrationTestMojo
+{
+  static final String PROPERTY_IVY_DEPLOY_FILE = "ivy.deploy.file";
+  
+  /** The file to deploy. Can either be a *.iar project file or a *.zip file containing a full application (set of projects). By default the packed IAR from the {@link IarPackagingMojo#GOAL} is used. */
+  @Parameter(property=PROPERTY_IVY_DEPLOY_FILE, defaultValue="${project.build.directory}/${project.artifactId}-${project.version}.iar")
+  protected File deployFile;
+  
+  /** 
+   * If set to <code>true</code> then test users defined in the projects are deployed to the engine.
+   * If set to <code>auto</code> then test users will only deployed when engine runs in demo mode.
+   * Should only be used for testing.
+   * <p>This option is only in charge if security system is set to <i>Ivy Security System</i>.
+   * This means if the security system is Active Directory or Novell eDirectory test users will never deployed.</p>
+   */
+  @Parameter(property="ivy.deploy.test.users", defaultValue=DefaultDeployOptions.DEPLOY_TEST_USERS)
+  public String deployTestUsers;
+
+  /** If set to <code>true</code> then configurations (global variables, external database, web services, REST clients)
+   * defined in the deployed projects overwrite the configurations that are already configured on the engine. */
+  @Parameter(property="ivy.deploy.configuration.overwrite", defaultValue="false")
+  public boolean deployConfigOverwrite;
+
+  /**
+   * Controls whether all configurations (global variables, external database, web services, REST clients) should be cleaned.
+   *
+   * <p>Possible values:</p>
+   * <ul>
+   *    <li><code>DISABLED</code>: all configurations will be kept on the application.</li>
+   *    <li><code>REMOVE_UNUSED</code>: all configurations that are not used by any projects deployed on the application will be removed after the deployment.</li>
+   *    <li><code>REMOVE_ALL</code>: all configurations of the application are removed before the deployment.<br>
+   *    <strong>Should only be used for development or test engines.<br>
+   *    Do not use in productive systems because it could break already deployed projects! </strong></li>
+   * </ul>
+   */
+  @Parameter(property="ivy.deploy.configuration.cleanup", defaultValue=DefaultDeployOptions.CLEANUP_DISABLED)
+  public String deployConfigCleanup;
+
+  /**
+   * The target version controls on which process model version (PMV) a project is re-deployed.
+   *
+   * <p>Matching:</p>
+   * <ul>
+   *    <li>In all cases the library identifier (group id and project/artifact id) of the PMV and the project has to be equal.</li>
+   *    <li>If multiple PMVs match the target version then the PMV with the highest library version is chosen.</li>
+   *    <li>If no PMV matches the target version then a new PMV is created and the project is deployed to the new PMV.</li>
+   * </ul>
+   *
+   * <p>Possible values:</p>
+   * <ul>
+   *    <li><code>AUTO</code>: a project is re-deployed if the version of the PMV is equal to the project's version.</li>
+   *    <li><code>RELEASED</code>: a project is re-deployed to the released PMV. The version of the PMV and the project does not matter</li>
+   *    <li>Maven version range: a project is re-deployed if the version of the PMV matches the given range. Some samples:
+   *       <ul>
+   *         <li><code>,</code> - Matches all version.</li>
+   *         <li><code>,2.5]</code> - Matches every version up to 2.5 inclusive.</li>
+   *         <li><code>(2.5,</code> - Matches every version from 2.5 exclusive.</li>
+   *         <li><code>[2.0,3.0)</code> - Matches every version from 2.0 inclusive up to 3.0 exclusive.</li>
+   *         <li><code>2.5</code> - Matches every version from 2.5 inclusive.</li>
+   *       </ul>
+   *    </li>
+   * </ul>
+   */
+  @Parameter(property="ivy.deploy.target.version", defaultValue=DefaultDeployOptions.VERSION_AUTO)
+  public String deployTargetVersion;
+
+  /**
+   * The target state of all process model versions (PMVs) of the deployed projects.
+   *
+   * <ul>
+   *   <li><code>ACTIVE_AND_RELEASED</code>: PMVs are activated and released after the deployment</li>
+   *   <li><code>ACTIVE</code>: PMVs are activated but not released after the deployment</li>
+   *   <li><code>INACTIVE</code>: PMVs are neither activated nor released after the deployment</li>
+   * </ul>
+   */
+  @Parameter(property="ivy.deploy.target.state", defaultValue=DefaultDeployOptions.STATE_ACTIVE_AND_RELEASED)
+  public String deployTargetState;
+
+  /**
+   * The target file format as which the project will be deployed into the process model version (PMV).
+   *
+   * <ul>
+   *    <li><code>AUTO</code>: Keep the format of the origin project file if possible. Deploys IAR or ZIP projects into a ZIP process model version. <br>
+   *        But if the target PMV already exists as expanded directory, the new version will be expanded as well.</li>
+   *    <li><code>PACKED</code>: Enforce the deployment of a project as zipped file. Normal (expanded) project directories will be compressed into a ZIP during deployment.</li>
+   *    <li><code>EXPANDED</code>: Enforce the deployment of a project as expanded file directory.<br>
+   *        This is recommended for projects that change the project files at runtime. E.g. projects that use the Content Management (CMS) write API.<br>
+   *        The expanded format behaves exactly like projects deployed with Axon.ivy 7.0 or older. You might choose to deploy expanded projects in order to avoid {@link ReadOnlyFileSystemException} at runtime.<br>
+   *        <strong>Warning</strong>: Expanded projects will perform slower at runtime and are therefore not recommended.</li>
+   * </ul>
+   * */
+  @Parameter(property = "ivy.deploy.target.file.format", defaultValue = DefaultDeployOptions.FILE_FORMAT_AUTO)
+  public String deployTargetFileFormat;
+  
+  /** The file that contains deployment options. <br/>
+  *
+  * Example options file content:
+  * <pre><code>deployTestUsers: auto
+  *configuration:
+  *  overwrite: true
+  *  cleanup: REMOVE_UNUSED
+  *target:
+  *  version: RELEASED
+  *  state: ACTIVE_AND_RELEASED</code></pre>
+  *
+  *  <p>Inside the options file you can use property placeholders. The options file may look like this:</p>
+  *  <pre><code>deployTestUsers: ${ivy.deploy.test.users}
+  *configuration:
+  *  overwrite: true
+  *  cleanup: REMOVE_UNUSED
+  *target:
+  *  version: AUTO
+  *  state: ${ivy.deploy.target.state}</code></pre>
+  *
+  *  <p>All options in this file are optional. You only need to specify options that overwrite the default behavior.</p>
+  *  <p>If configured, all Maven properties are ignored and only values in this file are used.</p>
+  *
+  * @see <a href="https://developer.axonivy.com/doc/7.1.latest/EngineGuideHtml/administration.html#administration.deployment.directory.options">Engine Guide</a>
+  */
+  @Parameter(property = "ivy.deploy.options.file", required = false)
+  protected File deployOptionsFile;
+  
+  @Component
+  private MavenFileFilter fileFilter;
+  @Parameter(property = "project", required = false, readonly = true)
+  protected MavenProject project;
+  @Parameter(property = "session", required = true, readonly = true)
+  protected MavenSession session;
+  
+  /** The maximum amount of seconds that we wait for a deployment result from the engine */
+  @Parameter(property="ivy.deploy.timeout.seconds", defaultValue="30")
+  protected Integer deployTimeoutInSeconds;
+
+  /** Set to <code>true</code> to skip the deployment to the engine. */
+  @Parameter(defaultValue="false", property="ivy.deploy.skip")
+  protected boolean skipDeploy;
+  
+  /** The name of an ivy application to which the file is deployed. */
+  @Parameter(property="ivy.deploy.engine.app")
+  String deployToEngineApplication;
+  
+  public AbstractDeployMojo()
+  {
+    super();
+  }
+
+  protected final boolean checkSkip()
+  {
+    if (skipDeploy)
+    {
+      getLog().info("Skipping deployment to engine.");
+      return true;
+    }
+    if (!deployFile.exists())
+    {
+      getLog().warn("Skipping deployment of '"+deployFile+"' to engine. The file does not exist.");
+      return true;
+    }
+    return false;
+  }
+  
+  protected final File createDeployOptionsFile(DeploymentOptionsFileFactory optionsFileFactory) throws MojoExecutionException
+  {
+    if (deployOptionsFile != null)
+    {
+      return optionsFileFactory.createFromTemplate(deployOptionsFile, project, session, fileFilter);
+    }
+  
+    try
+    {
+      String yamlOptions = YamlOptionsFactory.toYaml(this);
+      if (StringUtils.isNotBlank(yamlOptions))
+      {
+        return optionsFileFactory.createFromConfiguration(yamlOptions);
+      }
+    }
+    catch (IOException ex)
+    {
+      throw new MojoExecutionException("Failed to generate YAML option", ex);
+    }
+    return null;
+  }
+  
+  protected static final void removeTemporaryDeploymentOptionsFile(File deploymentOptionsFile)
+  {
+    FileUtils.deleteQuietly(deploymentOptionsFile);
+  }
+  
+  protected final void deployToDirectory(File resolvedOptionsFile, File deployDir) throws MojoExecutionException
+  {
+    File targetDeployableFile = createTargetDeployableFile(deployDir);
+    String deployablePath = deployDir.toPath().relativize(targetDeployableFile.toPath()).toString();
+    IvyDeployer deployer = new FileDeployer(deployDir, resolvedOptionsFile, deployTimeoutInSeconds, deployFile, targetDeployableFile);
+    deployer.deploy(deployablePath, getLog());
+  }
+  
+  private final File createTargetDeployableFile(File deployDir)
+  {
+    File deployApp = new File(deployDir, deployToEngineApplication);
+    File targetDeployableFile = new File(deployApp, deployFile.getName());
+    return targetDeployableFile;
+  }
+
+}

--- a/src/main/java/ch/ivyteam/ivy/maven/DeployToEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/DeployToEngineMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 AXON Ivy AG
+ * Copyright (C) 2020 AXON Ivy AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,26 +17,16 @@
 package ch.ivyteam.ivy.maven;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
-import java.nio.file.ReadOnlyFileSystemException;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Server;
-import org.apache.maven.shared.filtering.MavenFileFilter;
 
 import ch.ivyteam.ivy.maven.engine.deploy.DeploymentOptionsFileFactory;
-import ch.ivyteam.ivy.maven.engine.deploy.YamlOptionsFactory;
-import ch.ivyteam.ivy.maven.engine.deploy.dir.FileDeployer;
-import ch.ivyteam.ivy.maven.engine.deploy.dir.IvyDeployer;
 import ch.ivyteam.ivy.maven.engine.deploy.http.HttpDeployer;
 
 /**
@@ -60,28 +50,19 @@ import ch.ivyteam.ivy.maven.engine.deploy.http.HttpDeployer;
  * @since 7.1.0
  */
 @Mojo(name = DeployToEngineMojo.GOAL, requiresProject=false)
-public class DeployToEngineMojo extends AbstractIntegrationTestMojo
+public class DeployToEngineMojo extends AbstractDeployMojo
 {
   private static final String DEPLOY_ENGINE_DIR_DEFAULT = "${"+ENGINE_DIRECTORY_PROPERTY+"}";
-  private static final String DEPLOY_DEFAULT = "deploy";
   private static final String HTTP_ENGINE_URL_DEFAULT = "http://localhost:8080/ivy";
 
-  static final String PROPERTY_IVY_DEPLOY_FILE = "ivy.deploy.file";
+  static final String DEPLOY_DEFAULT = "deploy";
 
   public static final String GOAL = "deploy-to-engine";
-
-  /** The file to deploy. Can either be a *.iar project file or a *.zip file containing a full application (set of projects). By default the packed IAR from the {@link IarPackagingMojo#GOAL} is used. */
-  @Parameter(property=PROPERTY_IVY_DEPLOY_FILE, defaultValue="${project.build.directory}/${project.artifactId}-${project.version}.iar")
-  File deployFile;
 
   /** The path to the AXON.IVY Engine to which we deploy the file. <br/>
    * The path can reference a remote engine by using UNC paths e.g. <code>\\myRemoteHost\myEngineShare</code> */
   @Parameter(property="ivy.deploy.engine.dir", defaultValue=DEPLOY_ENGINE_DIR_DEFAULT)
   File deployEngineDirectory;
-  
-  /** The name of an ivy application to which the file is deployed. */
-  @Parameter(property="ivy.deploy.engine.app", required = true)
-  String deployToEngineApplication;
   
   /** The auto deployment directory of the engine. Must match the ivy engine system property 'deployment.directory' */
   @Parameter(property="ivy.deploy.dir", defaultValue=DEPLOY_DEFAULT)
@@ -114,170 +95,44 @@ public class DeployToEngineMojo extends AbstractIntegrationTestMojo
   @Parameter(property="ivy.deploy.engine.url", defaultValue=HTTP_ENGINE_URL_DEFAULT)
   String deployEngineUrl;
   
-  /** The file that contains deployment options. <br/>
-   *
-   * Example options file content:
-   * <pre><code>deployTestUsers: auto
-   *configuration:
-   *  overwrite: true
-   *  cleanup: REMOVE_UNUSED
-   *target:
-   *  version: RELEASED
-   *  state: ACTIVE_AND_RELEASED</code></pre>
-   *
-   *  <p>Inside the options file you can use property placeholders. The options file may look like this:</p>
-   *  <pre><code>deployTestUsers: ${ivy.deploy.test.users}
-   *configuration:
-   *  overwrite: true
-   *  cleanup: REMOVE_UNUSED
-   *target:
-   *  version: AUTO
-   *  state: ${ivy.deploy.target.state}</code></pre>
-   *
-   *  <p>All options in this file are optional. You only need to specify options that overwrite the default behavior.</p>
-   *  <p>If configured, all Maven properties are ignored and only values in this file are used.</p>
-   *
-   * @see <a href="https://developer.axonivy.com/doc/7.1.latest/EngineGuideHtml/administration.html#administration.deployment.directory.options">Engine Guide</a>
-   */
-  @Parameter(property="ivy.deploy.options.file", required=false)
-  File deployOptionsFile;
-
-  /** The maximum amount of seconds that we wait for a deployment result from the engine */
-  @Parameter(property="ivy.deploy.timeout.seconds", defaultValue="30")
-  Integer deployTimeoutInSeconds;
-
-  /** Set to <code>true</code> to skip the deployment to the engine. */
-  @Parameter(defaultValue="false", property="ivy.deploy.skip")
-  boolean skipDeploy;
-
-  /** If set to <code>true</code> then test users defined in the projects are deployed to the engine.
-   * If set to <code>auto</code> then test users will only deployed when engine runs in demo mode.
-   * Should only be used for testing.
-   * <p>This option is only in charge if security system is set to <i>Ivy Security System</i>.
-   * This means if the security system is Active Directory or Novell eDirectory test users will never deployed.</p>
-   */
-  @Parameter(property="ivy.deploy.test.users", defaultValue=DefaultDeployOptions.DEPLOY_TEST_USERS)
-  public String deployTestUsers;
-
-  /** If set to <code>true</code> then configurations (global variables, external database, web services, REST clients)
-   * defined in the deployed projects overwrite the configurations that are already configured on the engine. */
-  @Parameter(property="ivy.deploy.configuration.overwrite", defaultValue="false")
-  public boolean deployConfigOverwrite;
-
-  /**
-   * Controls whether all configurations (global variables, external database, web services, REST clients) should be cleaned.
-   *
-   * <p>Possible values:</p>
-   * <ul>
-   *    <li><code>DISABLED</code>: all configurations will be kept on the application.</li>
-   *    <li><code>REMOVE_UNUSED</code>: all configurations that are not used by any projects deployed on the application will be removed after the deployment.</li>
-   *    <li><code>REMOVE_ALL</code>: all configurations of the application are removed before the deployment.<br>
-   *    <strong>Should only be used for development or test engines.<br>
-   *    Do not use in productive systems because it could break already deployed projects! </strong></li>
-   * </ul>
-   */
-  @Parameter(property="ivy.deploy.configuration.cleanup", defaultValue=DefaultDeployOptions.CLEANUP_DISABLED)
-  public String deployConfigCleanup;
-
-  /**
-   * The target version controls on which process model version (PMV) a project is re-deployed.
-   *
-   * <p>Matching:</p>
-   * <ul>
-   *    <li>In all cases the library identifier (group id and project/artifact id) of the PMV and the project has to be equal.</li>
-   *    <li>If multiple PMVs match the target version then the PMV with the highest library version is chosen.</li>
-   *    <li>If no PMV matches the target version then a new PMV is created and the project is deployed to the new PMV.</li>
-   * </ul>
-   *
-   * <p>Possible values:</p>
-   * <ul>
-   *    <li><code>AUTO</code>: a project is re-deployed if the version of the PMV is equal to the project's version.</li>
-   *    <li><code>RELEASED</code>: a project is re-deployed to the released PMV. The version of the PMV and the project does not matter</li>
-   *    <li>Maven version range: a project is re-deployed if the version of the PMV matches the given range. Some samples:
-   *       <ul>
-   *         <li><code>,</code> - Matches all version.</li>
-   *         <li><code>,2.5]</code> - Matches every version up to 2.5 inclusive.</li>
-   *         <li><code>(2.5,</code> - Matches every version from 2.5 exclusive.</li>
-   *         <li><code>[2.0,3.0)</code> - Matches every version from 2.0 inclusive up to 3.0 exclusive.</li>
-   *         <li><code>2.5</code> - Matches every version from 2.5 inclusive.</li>
-   *       </ul>
-   *    </li>
-   * </ul>
-   */
-  @Parameter(property="ivy.deploy.target.version", defaultValue=DefaultDeployOptions.VERSION_AUTO)
-  public String deployTargetVersion;
-
-  /**
-   * The target state of all process model versions (PMVs) of the deployed projects.
-   *
-   * <ul>
-   *   <li><code>ACTIVE_AND_RELEASED</code>: PMVs are activated and released after the deployment</li>
-   *   <li><code>ACTIVE</code>: PMVs are activated but not released after the deployment</li>
-   *   <li><code>INACTIVE</code>: PMVs are neither activated nor released after the deployment</li>
-   * </ul>
-   */
-  @Parameter(property="ivy.deploy.target.state", defaultValue=DefaultDeployOptions.STATE_ACTIVE_AND_RELEASED)
-  public String deployTargetState;
-
-  /**
-   * The target file format as which the project will be deployed into the process model version (PMV).
-   *
-   * <ul>
-   *    <li><code>AUTO</code>: Keep the format of the origin project file if possible. Deploys IAR or ZIP projects into a ZIP process model version. <br>
-   *        But if the target PMV already exists as expanded directory, the new version will be expanded as well.</li>
-   *    <li><code>PACKED</code>: Enforce the deployment of a project as zipped file. Normal (expanded) project directories will be compressed into a ZIP during deployment.</li>
-   *    <li><code>EXPANDED</code>: Enforce the deployment of a project as expanded file directory.<br>
-   *        This is recommended for projects that change the project files at runtime. E.g. projects that use the Content Management (CMS) write API.<br>
-   *        The expanded format behaves exactly like projects deployed with Axon.ivy 7.0 or older. You might choose to deploy expanded projects in order to avoid {@link ReadOnlyFileSystemException} at runtime.<br>
-   *        <strong>Warning</strong>: Expanded projects will perform slower at runtime and are therefore not recommended.</li>
-   * </ul>
-   * */
-  @Parameter(property = "ivy.deploy.target.file.format", defaultValue = DefaultDeployOptions.FILE_FORMAT_AUTO)
-  public String deployTargetFileFormat;
-
-  @Component
-  private MavenFileFilter fileFilter;
-
-  @Parameter(property = "project", required = false, readonly = true)
-  MavenProject project;
-
-  @Parameter(property = "session", required = true, readonly = true)
-  MavenSession session;
-
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException
   {
-    if (skipDeploy)
-    {
-      getLog().info("Skipping deployment to engine.");
-      return;
-    }
     warnDeprectadIarProperty();
-    if (!deployFile.exists())
+    if (checkSkip())
     {
-      getLog().warn("Skipping deployment of '"+deployFile+"' to engine. The file does not exist.");
       return;
     }
-    File resolvedOptionsFile = createDeployOptionsFile();
+    if (StringUtils.isEmpty(deployToEngineApplication))
+    {
+      throw new MojoExecutionException("The parameter '"+deployToEngineApplication+"' for goal "+GOAL+" is missing.");
+    }
+    
+    File resolvedOptionsFile = createDeployOptionsFile(new DeploymentOptionsFileFactory(deployFile));
     try
     {
-      getLog().info("Deploying project "+deployFile.getName());
-      if (DeployMethod.DIRECTORY.equals(deployMethod))
-      {
-        deployToDirectory(resolvedOptionsFile);
-      }
-      else if (DeployMethod.HTTP.equals(deployMethod))
-      {
-        deployToRestService(resolvedOptionsFile);
-      }
-      else
-      {
-        getLog().warn("Invalid deploy method  "+deployMethod+" configured in parameter deployMethod (Supported values are "+DeployMethod.DIRECTORY+", "+DeployMethod.HTTP+")");
-      }
+      deployWithOptions(resolvedOptionsFile);
     }
     finally
     {
       removeTemporaryDeploymentOptionsFile(resolvedOptionsFile);
+    }
+  }
+  
+  private void deployWithOptions(File resolvedOptionsFile) throws MojoExecutionException
+  {
+    getLog().info("Deploying project "+deployFile.getName());
+    if (DeployMethod.DIRECTORY.equals(deployMethod))
+    {
+      deployToDirectory(resolvedOptionsFile);
+    }
+    else if (DeployMethod.HTTP.equals(deployMethod))
+    {
+      deployToRestService(resolvedOptionsFile);
+    }
+    else
+    {
+      getLog().warn("Invalid deploy method  "+deployMethod+" configured in parameter deployMethod (Supported values are "+DeployMethod.DIRECTORY+", "+DeployMethod.HTTP+")");
     }
   }
 
@@ -299,11 +154,7 @@ public class DeployToEngineMojo extends AbstractIntegrationTestMojo
     
     checkDirParams();
   
-    File targetDeployableFile = createTargetDeployableFile(deployDir);
-    String deployablePath = deployDir.toPath().relativize(targetDeployableFile.toPath()).toString();
-  
-    IvyDeployer deployer = new FileDeployer(deployDir, resolvedOptionsFile, deployTimeoutInSeconds, deployFile, targetDeployableFile);
-    deployer.deploy(deployablePath, getLog());
+    deployToDirectory(resolvedOptionsFile, deployDir);
   }
 
   private void deployToRestService(File resolvedOptionsFile) throws MojoExecutionException
@@ -363,13 +214,6 @@ public class DeployToEngineMojo extends AbstractIntegrationTestMojo
     return new File(deployEngineDirectory, deployDirectory);
   }
 
-  private File createTargetDeployableFile(File deployDir)
-  {
-    File deployApp = new File(deployDir, deployToEngineApplication);
-    File targetDeployableFile = new File(deployApp, deployFile.getName());
-    return targetDeployableFile;
-  }
-
   @SuppressWarnings("deprecation")
   private void warnDeprectadIarProperty()
   {
@@ -380,35 +224,6 @@ public class DeployToEngineMojo extends AbstractIntegrationTestMojo
       getLog().warn("Please migrate to the new property '"+PROPERTY_IVY_DEPLOY_FILE+"'.");
     }
   }
-
-  private File createDeployOptionsFile() throws MojoExecutionException
-  {
-    DeploymentOptionsFileFactory optionsFileFactory = new DeploymentOptionsFileFactory(deployFile);
-    if (deployOptionsFile != null)
-    {
-      return optionsFileFactory.createFromTemplate(deployOptionsFile, project, session, fileFilter);
-    }
-
-    try
-    {
-      String yamlOptions = YamlOptionsFactory.toYaml(this);
-      if (StringUtils.isNotBlank(yamlOptions))
-      {
-        return optionsFileFactory.createFromConfiguration(yamlOptions);
-      }
-    }
-    catch (IOException ex)
-    {
-      throw new MojoExecutionException("Failed to generate YAML option", ex);
-    }
-    return null;
-  }
-  
-  private static void removeTemporaryDeploymentOptionsFile(File deploymentOptionsFile)
-  {
-    FileUtils.deleteQuietly(deploymentOptionsFile);
-  }
-
 
   public static interface DefaultDeployOptions
   {

--- a/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
@@ -54,10 +54,18 @@ public class DeployToTestEngineMojo extends AbstractDeployMojo
   @Parameter(property="ivy.deploy.deps.as.app", defaultValue="true")
   boolean deployDepsAsApp;
   
+  /** Set to <code>true</code> to skip the test deployment to engine. */
+  @Parameter(property="maven.test.skip", defaultValue="false")
+  boolean skipTest;
+  
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException
   {
     if (checkSkip())
+    {
+      return;
+    }
+    if (skipTest)
     {
       return;
     }

--- a/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
@@ -23,6 +23,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import ch.ivyteam.ivy.maven.engine.deploy.DeploymentOptionsFileFactory;
+import ch.ivyteam.ivy.maven.util.MavenProperties;
 
 /**
  * <p>Deploys a set of test projects (iar) or a full application (set of projects as zip) to a running test engine.</p>
@@ -33,6 +34,11 @@ import ch.ivyteam.ivy.maven.engine.deploy.DeploymentOptionsFileFactory;
 public class DeployToTestEngineMojo extends AbstractDeployMojo
 {
   public static final String TEST_GOAL = "deploy-to-test-engine";
+  
+  public static interface Property
+  {
+    String TEST_ENGINE_APP = "test.engine.app";
+  }
   
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException
@@ -46,6 +52,8 @@ public class DeployToTestEngineMojo extends AbstractDeployMojo
       deployToEngineApplication = project.getArtifactId();
       getLog().info("Using '"+deployToEngineApplication+"' as target app.");
     }
+    var props = new MavenProperties(project, getLog());
+    props.set(Property.TEST_ENGINE_APP, deployToEngineApplication);
     
     deployTestApp();
   }

--- a/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
@@ -34,6 +34,7 @@ import ch.ivyteam.ivy.maven.util.MavenRuntime;
 
 /**
  * <p>Deploys a set of test projects (iar) or a full application (set of projects as zip) to a running test engine.</p>
+ * <p>By default the IAR of the current project plus all declared IAR dependencies will be deployed to the test engine.</p>
  *
  * @since 9.1.0
  */

--- a/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 AXON Ivy AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.ivyteam.ivy.maven;
+
+import java.io.File;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+import ch.ivyteam.ivy.maven.engine.deploy.DeploymentOptionsFileFactory;
+
+/**
+ * <p>Deploys a set of test projects (iar) or a full application (set of projects as zip) to a running test engine.</p>
+ *
+ * @since 9.1.0
+ */
+@Mojo(name = DeployToTestEngineMojo.TEST_GOAL, requiresProject=true)
+public class DeployToTestEngineMojo extends AbstractDeployMojo
+{
+  public static final String TEST_GOAL = "deploy-to-test-engine";
+  
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException
+  {
+    if (checkSkip())
+    {
+      return;
+    }
+    if (deployToEngineApplication == null)
+    {
+      deployToEngineApplication = project.getArtifactId();
+      getLog().info("Using '"+deployToEngineApplication+"' as target app.");
+    }
+    
+    deployTestApp();
+  }
+
+  private void deployTestApp() throws MojoExecutionException
+  {
+    File resolvedOptionsFile = createDeployOptionsFile(new DeploymentOptionsFileFactory(deployFile));
+    try
+    {
+      File deployDir = new File(getEngineDir(project), DeployToEngineMojo.DEPLOY_DEFAULT);
+      deployToDirectory(resolvedOptionsFile, deployDir);
+    }
+    finally
+    {
+      removeTemporaryDeploymentOptionsFile(resolvedOptionsFile);
+    }
+  }
+
+}

--- a/src/main/java/ch/ivyteam/ivy/maven/IarPackagingMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/IarPackagingMojo.java
@@ -92,7 +92,7 @@ public class IarPackagingMojo extends AbstractMojo
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException
   {
-    String iarName = project.getArtifactId() + "-" + project.getVersion() + "." + project.getPackaging();
+    String iarName = project.getArtifactId() + "-" + project.getVersion() + ".iar";
     File iar = new File(project.getBuild().getDirectory(), iarName);
     createIvyArchive(project.getBasedir(), iar);
 

--- a/src/main/java/ch/ivyteam/ivy/maven/SetupIntegrationTestPropertiesMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/SetupIntegrationTestPropertiesMojo.java
@@ -29,7 +29,9 @@ import ch.ivyteam.ivy.maven.engine.EngineControl;
 import ch.ivyteam.ivy.maven.util.MavenProperties;
 
 /**
- * Shares crucial test engine internals with the forked JVM that runs tests.
+ * Shares crucial test engine internals with the forked JVM that runs tests.<br/>
+ * The property being set is called 'argLine' and classically being read by 'maven-failsafe-plugin'.
+ * 
  * @since 9.1
  */
 @Mojo(name = SetupIntegrationTestPropertiesMojo.GOAL)

--- a/src/main/java/ch/ivyteam/ivy/maven/SetupIntegrationTestPropertiesMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/SetupIntegrationTestPropertiesMojo.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 AXON Ivy AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.ivyteam.ivy.maven;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import ch.ivyteam.ivy.maven.engine.EngineControl;
+import ch.ivyteam.ivy.maven.util.MavenProperties;
+
+/**
+ * Shares crucial test engine internals with the forked JVM that runs tests.
+ * @since 9.1
+ */
+@Mojo(name = SetupIntegrationTestPropertiesMojo.GOAL)
+public class SetupIntegrationTestPropertiesMojo extends AbstractEngineMojo
+{
+  public static final String GOAL = "ivy-integration-test-properties";
+
+  @Parameter(property = "project", required = true, readonly = true)
+  MavenProject project;
+
+  static final String FAILSAFE_ARGLINE_PROPERTY="argLine";
+  
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException
+  {
+    var props = new MavenProperties(project, getLog());
+    String jmvArgProps = asJvmArgs(props, 
+      EngineControl.Property.TEST_ENGINE_URL, 
+      EngineControl.Property.TEST_ENGINE_LOG, 
+      DeployToTestEngineMojo.Property.TEST_ENGINE_APP
+    );
+    props.set(FAILSAFE_ARGLINE_PROPERTY, jmvArgProps);
+  }
+
+  private static String asJvmArgs(MavenProperties store, String... keys)
+  {
+    return Arrays.stream(keys)
+      .map(key -> "-D"+key+"="+store.get(key))
+      .collect(Collectors.joining(" "));
+  }
+
+}

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/YamlOptionsFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/YamlOptionsFactory.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
-import ch.ivyteam.ivy.maven.DeployToEngineMojo;
+import ch.ivyteam.ivy.maven.AbstractDeployMojo;
 import ch.ivyteam.ivy.maven.DeployToEngineMojo.DefaultDeployOptions;
 
 /**
@@ -19,16 +19,17 @@ import ch.ivyteam.ivy.maven.DeployToEngineMojo.DefaultDeployOptions;
  */
 public class YamlOptionsFactory
 {
+  private static YAMLFactory yamlFactory = initYamlFactory();
 
-  private static YAMLFactory yamlFactory;
-  static
+  private static YAMLFactory initYamlFactory()
   {
-    yamlFactory = new YAMLFactory();
-    yamlFactory.configure(MINIMIZE_QUOTES, true);
-    yamlFactory.configure(WRITE_DOC_START_MARKER, false);
+    YAMLFactory factory = new YAMLFactory();
+    factory.configure(MINIMIZE_QUOTES, true);
+    factory.configure(WRITE_DOC_START_MARKER, false);
+    return factory;
   }
 
-  public static String toYaml(DeployToEngineMojo config) throws IOException
+  public static String toYaml(AbstractDeployMojo config) throws IOException
   {
     StringWriter writer = new StringWriter();
     JsonGenerator gen = yamlFactory.createGenerator(writer);
@@ -49,7 +50,7 @@ public class YamlOptionsFactory
     return yaml;
   }
 
-  private static void writeTestUsers(DeployToEngineMojo config, JsonGenerator gen) throws IOException
+  private static void writeTestUsers(AbstractDeployMojo config, JsonGenerator gen) throws IOException
   {
     String deployTestUsers = config.deployTestUsers;
     if (!DefaultDeployOptions.DEPLOY_TEST_USERS.equalsIgnoreCase(deployTestUsers))
@@ -58,7 +59,7 @@ public class YamlOptionsFactory
     }
   }
   
-  private static void writeConfig(DeployToEngineMojo config, JsonGenerator gen) throws IOException
+  private static void writeConfig(AbstractDeployMojo config, JsonGenerator gen) throws IOException
   {
     boolean defaultCleanup = DefaultDeployOptions.CLEANUP_DISABLED.equals(config.deployConfigCleanup);
     if (config.deployConfigOverwrite || !defaultCleanup)
@@ -77,7 +78,7 @@ public class YamlOptionsFactory
     }
   }
 
-  private static void writeTarget(DeployToEngineMojo config, JsonGenerator gen) throws IOException
+  private static void writeTarget(AbstractDeployMojo config, JsonGenerator gen) throws IOException
   {
     boolean defaultVersion = DefaultDeployOptions.VERSION_AUTO.equals(config.deployTargetVersion);
     boolean defaultState = DefaultDeployOptions.STATE_ACTIVE_AND_RELEASED.equals(config.deployTargetState);

--- a/src/main/java/ch/ivyteam/ivy/maven/util/MavenProperties.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/util/MavenProperties.java
@@ -33,8 +33,19 @@ public class MavenProperties
 
   public void setMavenProperty(String key, String value)
   {
+    set(key, value);
+  }
+  
+  public void set(String key, String value)
+  {
     log.debug("share property '" + key + "' with value '" + StringUtils.abbreviate(value, 500) + "'");
     project.getProperties().put(key, value);
+  }
+  
+  @SuppressWarnings("unchecked")
+  public <T extends Object> T get(String key)
+  {
+    return (T) project.getProperties().get(key);
   }
 
 }

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -4,6 +4,9 @@
     <lifecycleMapping>
       <packagingType>iar</packagingType>
     </lifecycleMapping>
+    <lifecycleMapping>
+      <packagingType>iar-enginetest</packagingType>
+    </lifecycleMapping>
   </lifecycleMappings>
 </lifecycleMappingMetadata>
 

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -5,7 +5,7 @@
       <packagingType>iar</packagingType>
     </lifecycleMapping>
     <lifecycleMapping>
-      <packagingType>iar-enginetest</packagingType>
+      <packagingType>iar-integration-test</packagingType>
     </lifecycleMapping>
   </lifecycleMappings>
 </lifecycleMappingMetadata>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -24,7 +24,7 @@
 		</component>
 		<component>
 			<role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
-			<role-hint>iar-enginetest</role-hint>
+			<role-hint>iar-integration-test</role-hint>
 			<implementation>
 				org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping
 			</implementation>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -42,8 +42,9 @@
 						com.axonivy.ivy.ci:project-build-plugin:start-test-engine,
 						com.axonivy.ivy.ci:project-build-plugin:deploy-to-test-engine
 					</pre-integration-test>
-					<integration-test>org.apache.maven.plugins:maven-surefire-plugin:test</integration-test>
+					<integration-test>org.apache.maven.plugins:maven-failsafe-plugin:integration-test</integration-test>
 					<post-integration-test>com.axonivy.ivy.ci:project-build-plugin:stop-test-engine</post-integration-test>
+					<verify>org.apache.maven.plugins:maven-failsafe-plugin:verify</verify>
 					<install>org.apache.maven.plugins:maven-install-plugin:install</install>
 					<deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
 				</phases>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -40,7 +40,7 @@
 					<package>com.axonivy.ivy.ci:project-build-plugin:pack-iar</package>
 					<pre-integration-test>
 						com.axonivy.ivy.ci:project-build-plugin:start-test-engine,
-						com.axonivy.ivy.ci:project-build-plugin:deploy-to-engine
+						com.axonivy.ivy.ci:project-build-plugin:deploy-to-test-engine
 					</pre-integration-test>
 					<integration-test>org.apache.maven.plugins:maven-surefire-plugin:test</integration-test>
 					<post-integration-test>com.axonivy.ivy.ci:project-build-plugin:stop-test-engine</post-integration-test>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -22,5 +22,32 @@
 				</phases>
 			</configuration>
 		</component>
+		<component>
+			<role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+			<role-hint>iar-enginetest</role-hint>
+			<implementation>
+				org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping
+			</implementation>
+			<configuration>
+				<phases>
+					<initialize>com.axonivy.ivy.ci:project-build-plugin:installEngine</initialize>
+					<compile>com.axonivy.ivy.ci:project-build-plugin:compileProject</compile>
+					<test-compile>com.axonivy.ivy.ci:project-build-plugin:test-compile</test-compile>
+					<test>
+						com.axonivy.ivy.ci:project-build-plugin:ivy-test-properties,
+						org.apache.maven.plugins:maven-surefire-plugin:test
+					</test>
+					<package>com.axonivy.ivy.ci:project-build-plugin:pack-iar</package>
+					<pre-integration-test>
+						com.axonivy.ivy.ci:project-build-plugin:start-test-engine,
+						com.axonivy.ivy.ci:project-build-plugin:deploy-to-engine
+					</pre-integration-test>
+					<integration-test>org.apache.maven.plugins:maven-surefire-plugin:test</integration-test>
+					<post-integration-test>com.axonivy.ivy.ci:project-build-plugin:stop-test-engine</post-integration-test>
+					<install>org.apache.maven.plugins:maven-install-plugin:install</install>
+					<deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+				</phases>
+			</configuration>
+		</component>
 	</components>
 </component-set>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -42,7 +42,10 @@
 						com.axonivy.ivy.ci:project-build-plugin:start-test-engine,
 						com.axonivy.ivy.ci:project-build-plugin:deploy-to-test-engine
 					</pre-integration-test>
-					<integration-test>org.apache.maven.plugins:maven-failsafe-plugin:integration-test</integration-test>
+					<integration-test>
+						com.axonivy.ivy.ci:project-build-plugin:ivy-integration-test-properties,
+						org.apache.maven.plugins:maven-failsafe-plugin:integration-test
+					</integration-test>
 					<post-integration-test>com.axonivy.ivy.ci:project-build-plugin:stop-test-engine</post-integration-test>
 					<verify>org.apache.maven.plugins:maven-failsafe-plugin:verify</verify>
 					<install>org.apache.maven.plugins:maven-install-plugin:install</install>

--- a/src/site/apt/lifecycle.apt.vm
+++ b/src/site/apt/lifecycle.apt.vm
@@ -1,6 +1,6 @@
-IAR Lifecycle
+iar Lifecycle
 
- The project-build-plugin has a custom build lifecycle.
+ The project-build-plugin has a custom build lifecycle. It's enabled by setting the <<<\<packaging\>iar\</packaging\>>>> in your pom.xml.
 
 *-----*------*
  <<phase>>    | <<default executions>> 
@@ -18,3 +18,26 @@ IAR Lifecycle
 *-----*------*
  deploy       | org.apache.maven.plugins:maven-deploy-plugin:deploy 
 *-----*------*
+
+
+
+iar-integration-test Lifecycle
+
+ Web integration tests against an engine can conveniently be written with minimal POM configuration. \
+ Just change the packaging type to <<<\<packaging\>iar-integration-test\</packaging\>>>> on a project that contains integration tests. \
+ This will den enable the <iar-integration-test> plugin goal bindings which are required to run <<<@IvyWebTest>>> classes.
+
+ The <<<iar-integration-test>>> lifecycle adds the following additional bindings to the normal <<<iar>>> lifecycle:
+
+*-----*------*
+ pre-integration-test | ${project.groupId}:${project.artifactId}:{{{./start-test-engine-mojo.html}start-test-engine}}\
+              | ${project.groupId}:${project.artifactId}:{{{./deploy-to-test-engine-mojo.html}deploy-to-test-engine}} 
+*-----*------*ja
+ integration-test | ${project.groupId}:${project.artifactId}:{{{./ivy-integration-test-properties-mojo.html}ivy-integration-test-properties}}\
+              | org.apache.maven.plugins:maven-failsafe-plugin:integration-test 
+*-----*------*
+ post-integration-test | ${project.groupId}:${project.artifactId}:{{{./stop-test-engine-mojo.html}stop-test-engine}} 
+*-----*------*
+ verify      | org.apache.maven.plugins:maven-failsafe-plugin:verify 
+*-----*------*
+

--- a/src/site/apt/lifecycle.apt.vm
+++ b/src/site/apt/lifecycle.apt.vm
@@ -25,7 +25,7 @@ iar-integration-test Lifecycle
 
  Web integration tests against an engine can conveniently be written with minimal POM configuration. \
  Just change the packaging type to <<<\<packaging\>iar-integration-test\</packaging\>>>> on a project that contains integration tests. \
- This will den enable the <iar-integration-test> plugin goal bindings which are required to run <<<@IvyWebTest>>> classes.
+ This will enable the <iar-integration-test> plugin goal bindings which are required to run <<<@IvyWebTest>>> classes.
 
  The <<<iar-integration-test>>> lifecycle adds the following additional bindings to the normal <<<iar>>> lifecycle:
 

--- a/src/test/java/ch/ivyteam/ivy/maven/TestDeployToTestEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestDeployToTestEngineMojo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 AXON Ivy AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.ivyteam.ivy.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.codehaus.plexus.archiver.ArchiverException;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestDeployToTestEngineMojo
+{
+  @Test
+  public void autoAppZip() throws ArchiverException, IOException
+  {
+    DeployToTestEngineMojo mojo = deploy.getMojo();
+    mojo.deployToEngineApplication = "myApp";
+    
+    File appZip = mojo.createFullAppZip(List.of(
+            Files.createTempFile("demo", ".iar").toFile(), 
+            Files.createTempFile("demoTest", ".iar").toFile()));
+    assertThat(appZip.getName()).isEqualTo("myApp-app.zip");
+  }
+
+  @Rule
+  public ProjectMojoRule<DeployToTestEngineMojo> deploy = new ProjectMojoRule<>(
+          new File("src/test/resources/base"), DeployToTestEngineMojo.TEST_GOAL);
+
+}

--- a/src/test/java/ch/ivyteam/ivy/maven/TestShareIntegrationTestPropertiesMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestShareIntegrationTestPropertiesMojo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 AXON Ivy AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.ivyteam.ivy.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import ch.ivyteam.ivy.maven.engine.EngineControl;
+
+public class TestShareIntegrationTestPropertiesMojo
+{
+  @Rule
+  public ProjectMojoRule<SetupIntegrationTestPropertiesMojo> setupProps = new ProjectMojoRule<>(
+          new File("src/test/resources/base"), SetupIntegrationTestPropertiesMojo.GOAL);
+  
+  @Test
+  public void shareFailsafeProps() throws MojoExecutionException, MojoFailureException
+  {
+    Properties props = setupProps.project.getProperties();
+    String argLineBefore = (String)props.get(SetupIntegrationTestPropertiesMojo.FAILSAFE_ARGLINE_PROPERTY);
+    assertThat(argLineBefore).isNullOrEmpty();
+    
+    props.setProperty(EngineControl.Property.TEST_ENGINE_URL, "http://127.0.0.1:9999");
+    props.setProperty(EngineControl.Property.TEST_ENGINE_LOG, "/var/logs/ivy.log");
+    props.setProperty(DeployToTestEngineMojo.Property.TEST_ENGINE_APP, "myTstApp");
+    
+    SetupIntegrationTestPropertiesMojo mojo = setupProps.getMojo();
+    mojo.execute();
+    String argLine = (String)props.get(SetupIntegrationTestPropertiesMojo.FAILSAFE_ARGLINE_PROPERTY);
+    assertThat(argLine).isEqualTo("-Dtest.engine.url=http://127.0.0.1:9999 -Dtest.engine.log=/var/logs/ivy.log -Dtest.engine.app=myTstApp");
+  }
+  
+}


### PR DESCRIPTION
Providing @IvyWebTest POM infrastructure has become simple:

1. set <packaging>iar-integration-test</packaging>
2. define <build><testSourceDirectory>src_test</testSourceDirectory> ...
3. add some @IvyWebTest annotated files .. Filename is crucial should end with 'IT'. .... e.g. PortalLoginIT
