### PR TITLE
XIVY-494 fix: sanitize app name from non whitespace chars

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/DeployToTestEngineMojo.java
@@ -74,7 +74,7 @@ public class DeployToTestEngineMojo extends AbstractDeployMojo
     }
     if (deployToEngineApplication == null)
     {
-      deployToEngineApplication = project.getArtifactId();
+      deployToEngineApplication = toAppName(project.getArtifactId());
       getLog().info("Using '"+deployToEngineApplication+"' as target app.");
     }
     var props = new MavenProperties(project, getLog());
@@ -87,6 +87,11 @@ public class DeployToTestEngineMojo extends AbstractDeployMojo
     }
     
     deployTestApp();
+  }
+
+  static String toAppName(String artifact)
+  {
+    return artifact.replaceAll("\\W", "");
   }
 
   private void provideDepsAsAppZip()

--- a/src/test/java/ch/ivyteam/ivy/maven/TestDeployToTestEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestDeployToTestEngineMojo.java
@@ -77,6 +77,12 @@ public class TestDeployToTestEngineMojo
       }
     }
   }
+  
+  @Test
+  public void appNameSanitizing()
+  {
+    assertThat(DeployToTestEngineMojo.toAppName("ivy-webtest.pure5")).isEqualTo("ivywebtestpure5");
+  }
 
   @Rule
   public ProjectMojoRule<DeployToTestEngineMojo> deploy = new ProjectMojoRule<>(


### PR DESCRIPTION
- otherwise runtime app will be created with a different, but compliant
name ... and therefore not be found with our webtest EngineUrl.

