### PR TITLE
XIVY-4413 fix reflect access warnings on engine-stop  ... LTS 8

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineModuleHints.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineModuleHints.java
@@ -14,6 +14,9 @@ public class EngineModuleHints
     "java.base/java.lang=ALL-UNNAMED", 
      // ignore illegal reflective access warning at rest deployment because ProjectJaxRsClassesScanner#hackReflectionHelperToNonOsgiMode()
     "java.base/java.lang.reflect=ALL-UNNAMED", 
+     // on engine stop tomcat clears caches
+    "java.base/java.io=ALL-UNNAMED",
+    "java.rmi/sun.rmi.transport=ALL-UNNAMED",
      // allow ZipFileSystem readonly feature on engine with Java 11
     "jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED"
   );


### PR DESCRIPTION
- tomcat-catalina.jar seems to do some reflection work on stop, which we
mute since it only causes confusion for the plugin user.