### PR TITLE
XIVY-4505 fix: 'ivyTestVm' occassionally not in 'target' dir

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/bpm/test/IvyTestRuntime.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/bpm/test/IvyTestRuntime.java
@@ -40,7 +40,7 @@ public class IvyTestRuntime
   
   public File store(MavenProject project) throws IOException
   {
-    File target = new File(project.getBuild().getOutputDirectory()).getParentFile();
+    File target = new File(project.getBuild().getDirectory());
     File tstVmDir = new File(target, "ivyTestVm");
     tstVmDir.mkdir();
     store(tstVmDir);

--- a/src/test/java/ch/ivyteam/ivy/maven/TestSetupIvyTestPropertiesMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestSetupIvyTestPropertiesMojo.java
@@ -109,6 +109,15 @@ public class TestSetupIvyTestPropertiesMojo extends BaseEngineProjectMojoTest
     assertThat(props.getProperty(Key.PROJECT_LOCATIONS))
       .isEqualTo("<"+rule.getMojo().project.getBasedir().toURI()+">");
   }
+  
+  @Test
+  public void ivyTestRuntimeIO() throws IOException
+  {
+    IvyTestRuntime rt = new IvyTestRuntime();
+    rt.setProductDir(new File("/tmp/myEngine"));
+    File ivyTestVm = rt.store(rule.project);
+    assertThat(ivyTestVm.getParentFile().getName()).isEqualTo("target");
+  }
 
   @Rule
   public ProjectMojoRule<SetupIvyTestPropertiesMojo> rule = new TestPropertyMojoRule();


### PR DESCRIPTION
- avoid dirty workspaces for projects that stick to the old pattern,
where 'classes' dir is a child of the project, and not of the 'target'
as in normal maven projects.

see https://jira.axonivy.com/jira/browse/XIVY-4505