### PR TITLE
XIVY-5531 pack only-local dependencies: but include transient

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/MavenDependencyMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/MavenDependencyMojo.java
@@ -23,11 +23,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import ch.ivyteam.ivy.maven.engine.MavenProjectBuilderProxy;
+import ch.ivyteam.ivy.maven.util.MavenDependencies;
 
 /**
  * Copy <a href="https://maven.apache.org/pom.html#Dependencies">maven dependencies</a> to a specific folder.
@@ -54,6 +56,9 @@ public class MavenDependencyMojo extends AbstractProjectCompileMojo
   @Parameter(property="ivy.mvn.dep.skip", defaultValue="false")
   boolean skipMvnDependency;
   
+  @Parameter( defaultValue = "${session}", readonly = true)
+  private MavenSession session;
+  
   @Override
   protected void compile(MavenProjectBuilderProxy projectBuilder) throws Exception
   {
@@ -63,7 +68,7 @@ public class MavenDependencyMojo extends AbstractProjectCompileMojo
     }
     getLog().info("Copy maven dependencies...");
     
-    var deps = getDependencies("jar");
+    var deps = new MavenDependencies(project, session).localTransient();
     if (deps.isEmpty())
     {
       getLog().info("No maven dependencies were found.");

--- a/src/main/java/ch/ivyteam/ivy/maven/util/MavenDependencies.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/util/MavenDependencies.java
@@ -1,0 +1,109 @@
+package ch.ivyteam.ivy.maven.util;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * @since 9.2.2
+ */
+public class MavenDependencies
+{
+  private final MavenProject project;
+  private final MavenSession session;
+  private String typeFilter;
+
+  public MavenDependencies(MavenProject project, MavenSession session)
+  {
+    this.project = project;
+    this.session = session;
+  }
+  
+  public MavenDependencies type(String newTypeFilter)
+  {
+    this.typeFilter = newTypeFilter;
+    return this;
+  }
+  
+  public List<File> localTransient()
+  {
+    Stream<Artifact> artifacts = stream(project.getArtifacts())
+      .filter(this::isLocalDep);
+    return getFiles(artifacts);
+  }
+  
+  private boolean isLocalDep(Artifact artifact)
+  {
+    return artifact.getDependencyTrail().stream()
+      .filter(dep -> dep.contains(":iar")) // iar or iar-integration-test
+      .filter(dep -> !dep.startsWith(project.getGroupId()+":"+project.getArtifactId()+":"))
+      .findAny()
+      .isEmpty();
+  }
+  
+  public List<File> all()
+  {
+    return getFiles(stream(project.getArtifacts()));
+  }
+
+  private static Stream<Artifact> stream(Set<Artifact> deps)
+  {
+    if (deps == null)
+    {
+      return Stream.empty();
+    }
+    return deps.stream();
+  }
+  
+  private List<File> getFiles(Stream<Artifact> dependencies)
+  {
+    return dependencies
+      .filter(this::include)
+      .map(this::toFile)
+      .collect(Collectors.toList());
+  }
+  
+  private File toFile(Artifact artifact)
+  {
+    return findReactorProject(artifact)
+      .map(MavenProject::getBasedir)
+      .orElse(artifact.getFile());
+  }
+  
+  private boolean include(Artifact artifact)
+  {
+    if (typeFilter == null)
+    {
+      return true;
+    }
+    if (artifact == null)
+    {
+      return false;
+    }
+    return typeFilter.equals(artifact.getType());
+  }
+
+  private Optional<MavenProject> findReactorProject(Artifact artifact)
+  {
+    if (session == null)
+    {
+      return Optional.empty();
+    }
+    var projects = session.getProjectMap();
+    if (projects == null)
+    {
+      return Optional.empty();
+    }
+    String artifactKey = artifact.getGroupId()+":"+artifact.getArtifactId()+":"+artifact.getVersion();
+    MavenProject reactorProject = projects.get(artifactKey);
+    return Optional.ofNullable(reactorProject);
+  }
+  
+}

--- a/src/main/java/ch/ivyteam/ivy/maven/util/MavenRuntime.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/util/MavenRuntime.java
@@ -1,12 +1,8 @@
 package ch.ivyteam.ivy.maven.util;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
@@ -19,36 +15,6 @@ public class MavenRuntime
   
   public static List<File> getDependencies(MavenProject project, MavenSession session, String type)
   {
-    Set<Artifact> dependencies = project.getArtifacts();
-    if (dependencies == null)
-    {
-      return Collections.emptyList();
-    }
-    
-    List<File> deps = new ArrayList<>();
-    for(Artifact artifact : dependencies)
-    {
-      MavenProject reactorProject = findReactorProject(session, artifact);
-      if (reactorProject != null && reactorProject.getArtifact().getType().equals(type))
-      {
-        deps.add(reactorProject.getBasedir());
-      }
-      else if (artifact.getType().equals(type))
-      {
-        deps.add(artifact.getFile());
-      }
-    }
-    return deps;
-  }
-
-  private static MavenProject findReactorProject(MavenSession session, Artifact artifact)
-  {
-    if (session == null)
-    {
-      return null;
-    }
-    String artifactKey = artifact.getGroupId()+":"+artifact.getArtifactId()+":"+artifact.getVersion();
-    MavenProject reactorProject = session.getProjectMap().get(artifactKey);
-    return reactorProject;
+    return new MavenDependencies(project, session).type(type).all();
   }
 }


### PR DESCRIPTION
- do not pack deps which involve another 'iar' project.
- but give me the full artifact dependency tree for my local declared
deps.

also fixed: local reactor project dependencies win over declarations
from local repository (installed) projects.