### PR TITLE
Raise default version to 9.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Maven plugin for the automated building of Axon Ivy Projects.
 - Run the `project-build-plugin` pipeline with the `maven.central.release` profile.
 - Run the `ivy-core_release-raise-project-build-plugin-version` pipeline with the new release/snapshot versions.
 
+After the release (on the next SNAPSHOT build):
+
+- Update the default engine version in the [AbstractEngineMojo](src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java#L40)
+
 ## License
 
 The Apache License, Version 2.0

--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java
@@ -37,7 +37,7 @@ public abstract class AbstractEngineMojo extends AbstractMojo
 {
   /** keep synch with pom.xml &gt; reporting &gt; maven-plugin-plugin &gt; requirements */
   protected static final String MINIMAL_COMPATIBLE_VERSION = "9.3.0";
-  protected static final String DEFAULT_VERSION = "9.3.0";
+  protected static final String DEFAULT_VERSION = "9.4.0";
   
   protected static final String ENGINE_DIRECTORY_PROPERTY = "ivy.engine.directory";
   


### PR DESCRIPTION
Should fix build which uses the default version of the project-build-plugin for the right engine (e.g cockpit)