### PR TITLE
XIVY-5608 raise default ivy-version to 10.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.axonivy.ivy.ci</groupId>
   <artifactId>project-build-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>10.0.2-SNAPSHOT</version>
+  <version>10.0.3-SNAPSHOT</version>
 
   <name>Axon Ivy Project Build Plugin</name>
   <description>Maven plugin for the automated building of Axon Ivy Projects. Referenced from the pom.xml of Axon Ivy Projects.</description>

--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java
@@ -39,7 +39,7 @@ public abstract class AbstractEngineMojo extends AbstractMojo {
    * requirements
    */
   protected static final String MINIMAL_COMPATIBLE_VERSION = "10.0.0";
-  protected static final String DEFAULT_VERSION = "10.0.1";
+  protected static final String DEFAULT_VERSION = "10.0.3";
 
   protected static final String ENGINE_DIRECTORY_PROPERTY = "ivy.engine.directory";
 


### PR DESCRIPTION
- simplify the usage of the latest 10.0.3 engine APIs; here in particular, the new OAuth2 rest URI creators