### PR TITLE
XIVY-10909 adjust tests: use http-mock server to comply Http-Client

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/engine/download/URLEngineDownloader.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/download/URLEngineDownloader.java
@@ -64,7 +64,7 @@ public class URLEngineDownloader implements EngineDownloader {
       try (InputStream pageStream = Files.newInputStream(index)) {
         return findEngineDownloadUrl(pageStream);
       } finally {
-        Files.delete(index);
+        Files.deleteIfExists(index);
       }
     } catch (IOException ex) {
       throw new MojoExecutionException("Failed to find engine download link in list page " + engineListPageUrl, ex);

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/download/URLEngineDownloader.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/download/URLEngineDownloader.java
@@ -31,8 +31,8 @@ public class URLEngineDownloader implements EngineDownloader {
   private final VersionRange ivyVersionRange;
   private final Log log;
   private final File downloadDirectory;
-  private final ProxyInfoProvider proxies;
   private String zipFileName = null;
+  public ProxyInfoProvider proxies;
 
   public URLEngineDownloader(URL engineDownloadUrl, URL engineListPageUrl, String osArchitecture,
           String ivyVersion, VersionRange ivyVersionRange, Log log, File downloadDirectory,

--- a/src/test/java/ch/ivyteam/ivy/maven/TestInstallEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestInstallEngineMojo.java
@@ -15,12 +15,13 @@
  */
 package ch.ivyteam.ivy.maven;
 
+import static ch.ivyteam.ivy.maven.AbstractEngineMojo.DEFAULT_VERSION;
+import static ch.ivyteam.ivy.maven.InstallEngineMojo.DEFAULT_ARCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -30,6 +31,9 @@ import java.nio.file.Files;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.wink.client.MockHttpServer;
+import org.apache.wink.client.MockHttpServer.MockHttpServerResponse;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -41,6 +45,7 @@ import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.model.ZipParameters;
 
 public class TestInstallEngineMojo {
+
   private InstallEngineMojo mojo;
 
   @Rule
@@ -53,48 +58,57 @@ public class TestInstallEngineMojo {
     }
   };
 
-  @Test
-  public void testEngineDownload_defaultBehaviour() throws Exception {
-    MockHttpServer mockServer = new MockHttpServer(3333);
-    try {
-      mockServer.startServer();
-      String baseUrl = "http://localhost:" + mockServer.getServerPort();
-      MockHttpServer.MockHttpServerResponse listPageResponse = new MockHttpServer.MockHttpServerResponse();
-      String defaultEngineName = "AxonIvyEngine" + AbstractEngineMojo.DEFAULT_VERSION + ".46949_"
-              + InstallEngineMojo.DEFAULT_ARCH;
-      listPageResponse.setMockResponseContent(
-              "<a href=\"" + baseUrl + "/" + defaultEngineName + ".zip\">the engine!</a>");
-      File engineZip = createFakeEngineZip(mojo.ivyVersion);
-      MockHttpServer.MockHttpServerResponse engineZipResponse = createFakeZipResponse(engineZip);
-      mockServer.setMockHttpServerResponses(listPageResponse, engineZipResponse);
+  private MockHttpServer mockServer;
+  private String mockBaseUrl;
 
-      // test setup can not expand expression ${settings.localRepository}: so we
-      // setup an explicit temp dir!
-      mojo.engineCacheDirectory = Files.createTempDirectory("tmpRepo").toFile();
-      mojo.engineListPageUrl = new URL(baseUrl + "/listPageUrl.html");
-
-      File defaultEngineDir = new File(mojo.engineCacheDirectory, AbstractEngineMojo.DEFAULT_VERSION);
-      assertThat(defaultEngineDir).doesNotExist();
-      assertThat(mojo.engineDownloadUrl)
-              .as("Default config should favour to download an engine from the 'list page url'.").isNull();
-      assertThat(mojo.autoInstallEngine).isTrue();
-
-      mojo.execute();
-
-      assertThat(defaultEngineDir)
-              .as("Engine must be automatically downloaded")
-              .exists().isDirectory();
-      assertThat(defaultEngineDir)
-              .as("Engine directory should automatically be set to subdir of the local repository cache.")
-              .isEqualTo(mojo.getRawEngineDirectory());
-    } finally {
-      mockServer.stopServer();
-    }
+  @Before
+  public void startHttp() {
+    mockServer = new MockHttpServer(3333);
+    mockServer.startServer();
+    mockBaseUrl = "http://localhost:" + mockServer.getServerPort();
   }
 
-  private static MockHttpServer.MockHttpServerResponse createFakeZipResponse(File zip)
-          throws IOException, FileNotFoundException {
-    MockHttpServer.MockHttpServerResponse engineZipResponse = new MockHttpServer.MockHttpServerResponse();
+  @After
+  public void stopHttp() {
+    mockServer.stopServer();
+  }
+
+  private URL mockEngineZip() throws MalformedURLException {
+    return new URL(mockBaseUrl+"/fakeEngine.zip");
+  }
+
+  @Test
+  public void testEngineDownload_defaultBehaviour() throws Exception {
+    var listPageResponse = new MockHttpServerResponse();
+    String defaultEngineName = "AxonIvyEngine" + DEFAULT_VERSION + ".46949_" + DEFAULT_ARCH;
+    listPageResponse.setMockResponseContent(
+            "<a href=\"" + mockBaseUrl + "/" + defaultEngineName + ".zip\">the engine!</a>");
+    mockServer.setMockHttpServerResponses(listPageResponse, createFakeZipResponse(createFakeEngineZip(mojo.ivyVersion)));
+
+    // test setup can not expand expression ${settings.localRepository}: so we
+    // setup an explicit temp dir!
+    mojo.engineCacheDirectory = Files.createTempDirectory("tmpRepo").toFile();
+    mojo.engineListPageUrl = new URL(mockBaseUrl + "/listPageUrl.html");
+
+    File defaultEngineDir = new File(mojo.engineCacheDirectory, DEFAULT_VERSION);
+    assertThat(defaultEngineDir).doesNotExist();
+    assertThat(mojo.engineDownloadUrl)
+      .as("Default config should favour to download an engine from the 'list page url'.")
+      .isNull();
+    assertThat(mojo.autoInstallEngine).isTrue();
+
+    mojo.execute();
+
+    assertThat(defaultEngineDir)
+      .as("Engine must be automatically downloaded")
+      .exists().isDirectory();
+    assertThat(defaultEngineDir)
+      .as("Engine directory should automatically be set to subdir of the local repository cache.")
+      .isEqualTo(mojo.getRawEngineDirectory());
+  }
+
+  private static MockHttpServerResponse createFakeZipResponse(File zip) throws Exception {
+    var engineZipResponse = new MockHttpServerResponse();
     engineZipResponse.setMockResponseContentType("application/zip");
     FileInputStream fis = new FileInputStream(zip);
     byte[] zipBytes = IOUtils.toByteArray(fis);
@@ -143,6 +157,8 @@ public class TestInstallEngineMojo {
 
   @Test
   public void testEngineDownload_alreadyInstalledVersionTooOld() throws Exception {
+    mockServer.setMockHttpServerResponses(createFakeZipResponse(createFakeEngineZip(DEFAULT_VERSION)));
+
     final String outdatedVersion = "6.5.1";
     mojo.engineDirectory = createFakeEngineDir(outdatedVersion);
     assertThat(mojo.engineDirectory).isDirectory();
@@ -150,13 +166,12 @@ public class TestInstallEngineMojo {
 
     mojo.ivyVersion = "[10.0.0,11.1.0]";
     mojo.autoInstallEngine = true;
-    final String downloadVersion = AbstractEngineMojo.DEFAULT_VERSION;
-    mojo.engineDownloadUrl = createFakeEngineZip(downloadVersion).toURI().toURL();
+    mojo.engineDownloadUrl = mockEngineZip();
 
     mojo.execute();
     assertThat(mojo.engineDirectory.listFiles()).isNotEmpty();
     assertThat(new File(mojo.engineDirectory, getFakeLibraryPath(outdatedVersion))).doesNotExist();
-    assertThat(new File(mojo.engineDirectory, getFakeLibraryPath(downloadVersion))).exists();
+    assertThat(new File(mojo.engineDirectory, getFakeLibraryPath(DEFAULT_VERSION))).exists();
   }
 
   @Test
@@ -166,7 +181,8 @@ public class TestInstallEngineMojo {
     assertThat(mojo.engineDirectory.listFiles()).isEmpty();
 
     mojo.autoInstallEngine = true;
-    mojo.engineDownloadUrl = createFakeEngineZip(mojo.ivyVersion).toURI().toURL();
+    mockServer.setMockHttpServerResponses(createFakeZipResponse(createFakeEngineZip(mojo.ivyVersion)));
+    mojo.engineDownloadUrl = mockEngineZip();
 
     mojo.execute();
     assertThat(mojo.engineDirectory.listFiles()).isNotEmpty();
@@ -196,7 +212,8 @@ public class TestInstallEngineMojo {
     alreadyExistingFile.createNewFile();
 
     mojo.autoInstallEngine = true;
-    mojo.engineDownloadUrl = createFakeEngineZip(mojo.ivyVersion).toURI().toURL();
+    mockServer.setMockHttpServerResponses(createFakeZipResponse(createFakeEngineZip(DEFAULT_VERSION)));
+    mojo.engineDownloadUrl = mockEngineZip();
 
     mojo.execute();
 
@@ -208,7 +225,8 @@ public class TestInstallEngineMojo {
     mojo.engineDirectory = createTempDir("tmpEngine");
     mojo.autoInstallEngine = true;
     mojo.ivyVersion = "9999.0.0";
-    mojo.engineDownloadUrl = createFakeEngineZip(AbstractEngineMojo.DEFAULT_VERSION).toURI().toURL();
+    mockServer.setMockHttpServerResponses(createFakeZipResponse(createFakeEngineZip(DEFAULT_VERSION)));
+    mojo.engineDownloadUrl = mockEngineZip();
 
     try {
       mojo.execute();
@@ -236,10 +254,8 @@ public class TestInstallEngineMojo {
     mojo.ivyVersion = "[7.0.0,7.1.0]";
     mojo.restrictVersionToMinimalCompatible = false;
     mojo.osArchitecture = "Windows_x86";
-    assertThat(findLink(
-            "<a href=\"http://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>"))
-                    .isEqualTo(
-                            "http://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
+    assertThat(findLink("<a href=\"http://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>"))
+      .isEqualTo("http://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
   }
 
   @Test
@@ -247,10 +263,8 @@ public class TestInstallEngineMojo {
     mojo.ivyVersion = "[7.0.0,7.1.0]";
     mojo.restrictVersionToMinimalCompatible = false;
     mojo.osArchitecture = "Windows_x86";
-    assertThat(findLink(
-            "<a href=\"https://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>"))
-                    .isEqualTo(
-                            "https://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
+    assertThat(findLink("<a href=\"https://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>"))
+       .isEqualTo("https://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
   }
 
   @Test
@@ -260,7 +274,7 @@ public class TestInstallEngineMojo {
     mojo.osArchitecture = "Windows_x86";
     mojo.engineListPageUrl = new URL("http://localhost/");
     assertThat(findLink("<a href=\"7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>"))
-            .isEqualTo("http://localhost/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
+      .isEqualTo("http://localhost/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
   }
 
   @Test
@@ -270,8 +284,7 @@ public class TestInstallEngineMojo {
     mojo.osArchitecture = "Windows_x64";
     assertThat(findLink(
             "<a href=\"http://www.ivyteam.ch/downloads/XIVY/Saentis/7.0.0-S2/AxonIvyEngine7.0.0.47245.S2_Windows_x64.zip\">Axon Ivy Engine Windows x64</a>"))
-                    .isEqualTo(
-                            "http://www.ivyteam.ch/downloads/XIVY/Saentis/7.0.0-S2/AxonIvyEngine7.0.0.47245.S2_Windows_x64.zip");
+      .isEqualTo("http://www.ivyteam.ch/downloads/XIVY/Saentis/7.0.0-S2/AxonIvyEngine7.0.0.47245.S2_Windows_x64.zip");
   }
 
   @Test
@@ -311,12 +324,11 @@ public class TestInstallEngineMojo {
     assertThat(findLink(
             "<a href=\"7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>" // windows
                     + "<a href=\"7.0.0/AxonIvyEngine7.0.0.46949_Linux_x86.zip\">the latest engine</a>")) // linux
-                            .isEqualTo("http://localhost/7.0.0/AxonIvyEngine7.0.0.46949_Linux_x86.zip");
+      .isEqualTo("http://localhost/7.0.0/AxonIvyEngine7.0.0.46949_Linux_x86.zip");
   }
 
   private String findLink(String html) throws MojoExecutionException, MalformedURLException {
-    return getUrlDownloader().findEngineDownloadUrl(IOUtils.toInputStream(html, StandardCharsets.UTF_8))
-            .toExternalForm();
+    return getUrlDownloader().findEngineDownloadUrl(IOUtils.toInputStream(html, StandardCharsets.UTF_8)).toExternalForm();
   }
 
   @Test
@@ -326,13 +338,12 @@ public class TestInstallEngineMojo {
       return;
     }
 
-    String engineUrl = getUrlDownloader().findEngineDownloadUrl(mojo.engineListPageUrl.openStream())
-            .toExternalForm();
+    String engineUrl = getUrlDownloader().findEngineDownloadUrl(mojo.engineListPageUrl.openStream()).toExternalForm();
     assertThat(engineUrl)
-            .as("The default engine list page url '" + mojo.engineListPageUrl.toExternalForm() + "' "
-                    + "must provide an engine for the current default engine version '" + mojo.ivyVersion
-                    + "'.")
-            .contains(mojo.ivyVersion);
+      .as("The default engine list page url '" + mojo.engineListPageUrl.toExternalForm() + "' "
+              + "must provide an engine for the current default engine version '" + mojo.ivyVersion
+              + "'.")
+      .contains(mojo.ivyVersion);
   }
 
   private URLEngineDownloader getUrlDownloader() throws MojoExecutionException {
@@ -353,14 +364,14 @@ public class TestInstallEngineMojo {
   @Test
   public void testZipFileEngineVersionParser() {
     assertThat(InstallEngineMojo.ivyEngineVersionOfZip("AxonIvyEngine6.1.1.51869_Linux_x64.zip"))
-            .isEqualTo("6.1.1");
+      .isEqualTo("6.1.1");
     assertThat(InstallEngineMojo.ivyEngineVersionOfZip("AxonIvyEngine6.2_Windows_x64.zip"))
-            .isEqualTo("6.2");
+      .isEqualTo("6.2");
     assertThat(InstallEngineMojo
-            .ivyEngineVersionOfZip("AxonIvyDesigner6.1.1-SNAPSHOT.51869-win32.win32.x86_64.zip"))
-                    .isEqualTo("6.1.1");
+      .ivyEngineVersionOfZip("AxonIvyDesigner6.1.1-SNAPSHOT.51869-win32.win32.x86_64.zip"))
+      .isEqualTo("6.1.1");
     assertThat(InstallEngineMojo.ivyEngineVersionOfZip("AxonIvyEngine_Linux_x64.zip"))
-            .isEqualTo("AxonIvyEngine_Linux_x64.zip"); // do not return null!
+      .isEqualTo("AxonIvyEngine_Linux_x64.zip"); // do not return null!
   }
 
   private static String getFakeLibraryPath(final String version) {


### PR DESCRIPTION
- we can no longer simulate file:// downloads, but need a real URI