### PR TITLE
Revert "Bump maven-filtering from 3.2.0 to 3.3.1" > fix engine-cockpit build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
-      <version>3.3.1</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
This reverts commit 7404af07935216863dd5d9ace5db16d2ae6a659e.