### PR TITLE
Revert "Bump commons-io from 2.11.0 to 2.12.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.12.0</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This reverts commit ef53a017bb66a874e8a5c51b618003dd6a26c6c6.