### PR TITLE
XIVY-13820 fix: always deploy docs for public releases

### DIFF
--- a/build/release/Jenkinsfile
+++ b/build/release/Jenkinsfile
@@ -27,7 +27,8 @@ pipeline {
             setupGPGEnvironment()
             withCredentials([string(credentialsId: 'gpg.password', variable: 'GPG_PWD')]) {              
               def dryRun = isReleaseBranch() ? '' : '-DdryRun=true'
-              def args = "-PossrhDeploy -Divy.engine.list.url=${params.engineListUrl} -Dgpg.project-build.password='${env.GPG_PWD}'";
+              def args = "-PossrhDeploy -Divy.engine.list.url=${params.engineListUrl} -Dgpg.project-build.password='${env.GPG_PWD}'"+
+                " -Dgithub.site.skip=false";
               maven cmd: dryRun + ' -Darguments="' + args + '" -DpushChanges=false -DlocalCheckout=true release:prepare release:perform'
             }
 


### PR DESCRIPTION
official release were no longer run with docs: 
https://github.com/axonivy/project-build-plugin/blob/gh-pages/release/
did it manually back in time ...but with this change it should work again
https://jenkins.ivyteam.io/job/project-build-plugin/job/doc113/6/