### PR TITLE
XIVY-13820 fix: snapshots no linking official docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
     <!-- version should match ivy Engine sfl4j version! And version in EngineClassLoaderFactory.SLF4J_VERSION -->
     <slf4j.version>1.7.36</slf4j.version>
     <site.path>snapshot</site.path>
+    <other.site.path>release</other.site.path>
+    <other.site.name>Stable</other.site.name>
     <autoRelease>true</autoRelease>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <unit.tests.skip>false</unit.tests.skip>
@@ -390,6 +392,8 @@
       <id>ossrhDeploy</id>
       <properties>
         <site.path>release</site.path>
+        <other.site.path>snapshot</other.site.path>
+        <other.site.name>Snapshot</other.site.name>
         <maven.test.skip>true</maven.test.skip>
       </properties>
       <build>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -33,7 +33,7 @@ under the License.
     
     <menu name="Development">
       <item name="Source Code" href="http://github.com/axonivy/project-build-plugin" />
-      <item name="Snapshot Release" href="../../snapshot" />
+      <item name="${other.site.name} release" href="../../${other.site.path}" />
     </menu>
   </body>
   


### PR DESCRIPTION
re-invent the feature dropped with https://github.com/axonivy/project-build-plugin/pull/208/commits/82daa6abff4f0abd688937aebcf5e1344a1102b0 ...where I wasn't mentioned :man_shrugging: 

nowadays I don't see a big problem in maintaining these properties.

![unable-to-navigate-to-releases](https://github.com/axonivy/project-build-plugin/assets/15085693/767e0f7e-303b-47d3-b776-2f47e6d95056)
