### PR TITLE
XIVY-13820 fix: tagNameFormat not semantic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,16 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>3.0.1</version>
+          <configuration>
+            <tagNameFormat>v@{project.version}</tagNameFormat>
+            <releaseProfiles>release</releaseProfiles>
+            <goals>deploy site-deploy</goals>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -375,16 +385,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-release-plugin</artifactId>
-            <version>3.0.1</version>
-            <configuration>
-              <tagNameFormat>v@{project.version}</tagNameFormat>
-              <releaseProfiles>release</releaseProfiles>
-              <goals>deploy site-deploy</goals>
-            </configuration>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
do not work with the default tag format 'project-build-plugin-11.3.0' but use semantic 'v11.3.0'

- maven-release-plugin config in ossrhDeploy profile is inactive during maven-release-plugin:prepare runs
- I think since it's run in an own maven cycle à  la maven-invoker.

fixed ruN:
![mvn release:prepare_001](https://github.com/axonivy/project-build-plugin/assets/15085693/e8b35a02-fea5-4614-bd84-31eb207c02df)
