### PR TITLE
XIVY-13820 fix: tagNameFormat not semantic > R10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,16 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>3.0.1</version>
+          <configuration>
+            <tagNameFormat>v@{project.version}</tagNameFormat>
+            <releaseProfiles>release</releaseProfiles>
+            <goals>deploy site-deploy</goals>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -375,16 +385,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-release-plugin</artifactId>
-            <version>3.0.1</version>
-            <configuration>
-              <tagNameFormat>v@{project.version}</tagNameFormat>
-              <releaseProfiles>release</releaseProfiles>
-              <goals>deploy site-deploy</goals>
-            </configuration>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- maven-release-plugin config in ossrhDeploy profile is inactive during maven-release-plugin:prepare runs