### PR TITLE
Stabilize8

### DIFF
--- a/src/test/java/ch/ivyteam/ivy/maven/TestDeployToRunningEngine.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestDeployToRunningEngine.java
@@ -134,7 +134,11 @@ public class TestDeployToRunningEngine extends BaseEngineProjectMojoTest
     Executor startedProcess = null;
     try
     {
+      System.setOut(originalOut);
       startedProcess = mojo.startEngine();
+      deployMojo.deployEngineUrl = (String) rule.project.getProperties()
+              .get(EngineControl.Property.TEST_ENGINE_URL);
+      System.setOut(new PrintStream(outContent));
 
       deployMojo.execute();
 


### PR DESCRIPTION
the problem was 100% reproducible also on my node: by blocking the default engine port 8080.
the test replaces the original System.out stream, and therefore we shortly need to re-stablish the real system.out, in order to capture the port/engine-url ..

![failing8](https://github.com/axonivy/project-build-plugin/assets/15085693/9888bce9-719f-4834-ade3-85024f04578d)
