### PR TITLE
XIVY-14570 Upgrade to Maven 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <description>Maven plugin for the automated building of Axon Ivy Projects. Referenced from the pom.xml of Axon Ivy Projects.</description>
   <url>https://github.com/axonivy/project-build-plugin</url>
   <prerequisites>
-    <maven>${maven.version}</maven>
+    <maven>3.9.0</maven>
   </prerequisites>
   <licenses>
     <license>
@@ -40,7 +40,7 @@
 
   <properties>
     <java.version>21</java.version>
-    <maven.version>3.6.3</maven.version>
+    <maven.version>3.9.8</maven.version>
     <!-- version should match ivy Engine sfl4j version! And version in EngineClassLoaderFactory.SLF4J_VERSION -->
     <slf4j.version>2.0.13</slf4j.version>
     <junit-jupiter.version>5.10.3</junit-jupiter.version>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
-      <version>3.2.0</version>
+      <version>3.3.2</version>
       <!--NOT provided: will fail on consuming builds -->
     </dependency>
     <dependency>
@@ -126,7 +126,6 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
       <version>4.10.0</version>
-      <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -134,17 +133,17 @@
       <version>2.17.2</version>
     </dependency>
     <dependency>
-  	  <groupId>org.apache.httpcomponents</groupId>
-  	  <artifactId>httpclient</artifactId>
-  	  <version>4.5.14</version>
-  	  <scope>compile</scope>
-  	</dependency>
-  	<dependency>
-  	  <groupId>org.apache.httpcomponents</groupId>
-  	  <artifactId>httpmime</artifactId>
-  	  <version>4.5.14</version>
-  	  <scope>compile</scope>
-  	</dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.14</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>4.5.14</version>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- Logging environment: Required for engine classLoader (but not for the plugin runtime itself) -->
     <dependency>

--- a/src/main/java/ch/ivyteam/ivy/maven/compile/AbstractEngineInstanceMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/AbstractEngineInstanceMojo.java
@@ -32,6 +32,7 @@ import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory.MavenContext;
 import ch.ivyteam.ivy.maven.engine.MavenProjectBuilderProxy;
 import ch.ivyteam.ivy.maven.engine.Slf4jSimpleEngineProperties;
 
+@SuppressWarnings("deprecation")
 public abstract class AbstractEngineInstanceMojo extends AbstractEngineMojo {
   @Parameter(property = "project", required = true, readonly = true)
   public MavenProject project;

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
@@ -46,6 +46,7 @@ import ch.ivyteam.ivy.maven.util.SharedFile;
  * @author Reguel Wermelinger
  * @since 25.09.2014
  */
+@SuppressWarnings("deprecation")
 public class EngineClassLoaderFactory {
   public interface OsgiDir {
     String INSTALL_AREA = "system";

--- a/src/test/java/ch/ivyteam/ivy/maven/compile/CompileMojoRule.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/compile/CompileMojoRule.java
@@ -26,6 +26,7 @@ import org.apache.maven.plugin.internal.DefaultLegacySupport;
 import ch.ivyteam.ivy.maven.BaseEngineProjectMojoTest;
 import ch.ivyteam.ivy.maven.BaseEngineProjectMojoTest.EngineMojoRule;
 
+@SuppressWarnings("deprecation")
 public class CompileMojoRule<T extends AbstractEngineInstanceMojo> extends EngineMojoRule<T> {
   public CompileMojoRule(String mojoName) {
     super(mojoName);


### PR DESCRIPTION
I think it's time to move on.

![image](https://github.com/user-attachments/assets/fd56d566-2586-4799-ba42-09381ec86eac)

Maven 3.9 is now also bundled as part of M2E. 

Should also fix security issues:
https://github.com/axonivy/project-build-plugin/security/dependabot