### PR TITLE
Remove most of commons.io usages

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/InstallEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/InstallEngineMojo.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -42,6 +41,7 @@ import ch.ivyteam.ivy.maven.engine.EngineVersionEvaluator;
 import ch.ivyteam.ivy.maven.engine.download.EngineDownloader;
 import ch.ivyteam.ivy.maven.engine.download.MavenEngineDownloader;
 import ch.ivyteam.ivy.maven.engine.download.URLEngineDownloader;
+import ch.ivyteam.ivy.maven.util.PathUtils;
 import net.lingala.zip4j.ZipFile;
 
 /**
@@ -263,11 +263,10 @@ public class InstallEngineMojo extends AbstractEngineMojo {
     var dir = getRawEngineDirectory();
     try {
       if (dir != null) {
-        FileUtils.cleanDirectory(dir.toFile());
+        PathUtils.clean(dir);
       }
-    } catch (IOException ex) {
-      throw new MojoExecutionException(
-              "Failed to clean outdated ivy Engine directory '" + dir + "'.", ex);
+    } catch (Exception ex) {
+      throw new MojoExecutionException("Failed to clean outdated ivy Engine directory '" + dir + "'.", ex);
     }
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/MavenDependencyCleanupMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/MavenDependencyCleanupMojo.java
@@ -16,9 +16,6 @@
 
 package ch.ivyteam.ivy.maven;
 
-import java.io.IOException;
-
-import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -26,13 +23,16 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
+import ch.ivyteam.ivy.maven.util.PathUtils;
+
 /**
  * Delete copied maven dependencies in the lib/mvn-deps folder.
- * 
+ *
  * @since 9.2.0
  */
 @Mojo(name = MavenDependencyCleanupMojo.GOAL)
 public class MavenDependencyCleanupMojo extends AbstractMojo {
+
   public static final String GOAL = "maven-dependency-cleanup";
 
   @Parameter(property = "project", required = true, readonly = true)
@@ -51,12 +51,11 @@ public class MavenDependencyCleanupMojo extends AbstractMojo {
       return;
     }
     var mvnLibDir = project.getBasedir().toPath().resolve("lib").resolve("mvn-deps");
-    getLog().info("Deleting " + mvnLibDir.toString());
+    getLog().info("Deleting " + mvnLibDir);
     try {
-      FileUtils.deleteDirectory(mvnLibDir.toFile());
-    } catch (IOException ex) {
-      getLog().warn("Couldn't delete: " + mvnLibDir.toString(), ex);
+      PathUtils.delete(mvnLibDir);
+    } catch (Exception ex) {
+      getLog().warn("Couldn't delete: " + mvnLibDir, ex);
     }
   }
-
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/ShareEngineCoreClasspathMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/ShareEngineCoreClasspathMojo.java
@@ -47,10 +47,8 @@ public class ShareEngineCoreClasspathMojo extends AbstractEngineMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    List<File> ivyEngineClassPathFiles = EngineClassLoaderFactory
-            .getIvyEngineClassPathFiles(identifyAndGetEngineDirectory().toFile());
+    List<File> ivyEngineClassPathFiles = EngineClassLoaderFactory.getIvyEngineClassPathFiles(identifyAndGetEngineDirectory());
     String propertyValue = StringUtils.join(ivyEngineClassPathFiles, ",");
-
     MavenProperties properties = new MavenProperties(project, getLog());
     properties.setMavenProperty(IVY_ENGINE_CORE_CLASSPATH_PROPERTY, propertyValue);
   }

--- a/src/main/java/ch/ivyteam/ivy/maven/compile/AbstractEngineInstanceMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/AbstractEngineInstanceMojo.java
@@ -90,7 +90,7 @@ public abstract class AbstractEngineInstanceMojo extends AbstractEngineMojo {
               getLog(),
               timeoutEngineStartInSeconds);
     }
-    classLoaderFactory.writeEngineClasspathJar(toFile(engineDir));
+    classLoaderFactory.writeEngineClasspathJar(engineDir);
     // share engine directory as property for custom follow up plugins:
     if (engineDir != null) {
       project.getProperties().put(AbstractEngineMojo.ENGINE_DIRECTORY_PROPERTY, engineDir.toAbsolutePath().toString());

--- a/src/main/java/ch/ivyteam/ivy/maven/deploy/AbstractDeployMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/deploy/AbstractDeployMojo.java
@@ -16,13 +16,12 @@
 
 package ch.ivyteam.ivy.maven.deploy;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.ReadOnlyFileSystemException;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -244,12 +243,14 @@ public abstract class AbstractDeployMojo extends AbstractIntegrationTestMojo {
     return null;
   }
 
-  protected static final void removeTemporaryDeploymentOptionsFile(Path deploymentOptionsFile) {
-    FileUtils.deleteQuietly(toFile(deploymentOptionsFile));
-  }
-
-  private static File toFile(Path file) {
-    return file == null ? null : file.toFile();
+  protected static void deleteFile(Path file) {
+    if (file != null && Files.exists(file)) {
+      try {
+        Files.delete(file);
+      } catch (IOException ex) {
+        throw new UncheckedIOException("Could not delete " + file, ex);
+      }
+    }
   }
 
   protected final void deployToDirectory(Path resolvedOptionsFile, Path deployDir)

--- a/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToEngineMojo.java
@@ -141,7 +141,7 @@ public class DeployToEngineMojo extends AbstractDeployMojo {
     try {
       deployWithOptions(resolvedOptionsFile);
     } finally {
-      removeTemporaryDeploymentOptionsFile(resolvedOptionsFile);
+      deleteFile(resolvedOptionsFile);
     }
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToTestEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToTestEngineMojo.java
@@ -156,7 +156,7 @@ public class DeployToTestEngineMojo extends AbstractDeployMojo {
       var deployDir = getEngineDir(project).resolve(DeployToEngineMojo.DEPLOY_DEFAULT);
       deployToDirectory(resolvedOptionsFile, deployDir);
     } finally {
-      removeTemporaryDeploymentOptionsFile(resolvedOptionsFile);
+      deleteFile(resolvedOptionsFile);
     }
   }
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineControl.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineControl.java
@@ -41,7 +41,6 @@ import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.exec.ShutdownHookProcessDestroyer;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
 
@@ -272,8 +271,15 @@ public class EngineControl {
       executor.execute(statusCmd);
     } catch (IOException ex) { // expected!
     } finally {
+      try {
       engineOutput = outputStream.toString();
-      IOUtils.closeQuietly(outputStream);
+      } finally {
+        try {
+          outputStream.close();
+        } catch (IOException ex) {
+          throw new RuntimeException(ex);
+        }
+      }
     }
     return engineOutput;
   }

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineMojoContext.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineMojoContext.java
@@ -63,7 +63,7 @@ public class EngineMojoContext {
       try {
         log.info("Creating a classpath jar for starting the engine");
         new ClasspathJar(classpathJar.toFile())
-                .createFileEntries(EngineClassLoaderFactory.getOsgiBootstrapClasspath(engineDirectory.toFile()));
+                .createFileEntries(EngineClassLoaderFactory.getOsgiBootstrapClasspath(engineDirectory));
       } catch (Exception ex) {
         throw new RuntimeException(
                 "Could not create engine classpath jar: '" + classpathJar + "'", ex);

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/MavenProjectBuilderProxy.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/MavenProjectBuilderProxy.java
@@ -56,13 +56,13 @@ public class MavenProjectBuilderProxy {
 
     logEngine();
 
-    URLClassLoader ivyEngineClassLoader = classLoaderFactory.createEngineClassLoader(baseDirToBuildIn);
+    URLClassLoader ivyEngineClassLoader = classLoaderFactory.createEngineClassLoader(baseDirToBuildIn.toPath());
     delegateClass = getOsgiBundledDelegate(ivyEngineClassLoader, timeoutEngineStartInSeconds);
     Constructor<?> constructor = delegateClass.getDeclaredConstructor(File.class);
 
     delegate = executeInEngineDir(() -> constructor.newInstance(workspace));
 
-    List<File> engineJars = EngineClassLoaderFactory.getIvyEngineClassPathFiles(baseDirToBuildIn);
+    List<File> engineJars = EngineClassLoaderFactory.getIvyEngineClassPathFiles(baseDirToBuildIn.toPath());
     engineClasspath = getEngineClasspath(engineJars);
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/DeploymentOptionsFileFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/DeploymentOptionsFileFactory.java
@@ -6,12 +6,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collections;
 
-import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFilteringException;
+
+import ch.ivyteam.ivy.maven.util.PathUtils;
 
 public class DeploymentOptionsFileFactory {
 
@@ -28,8 +29,8 @@ public class DeploymentOptionsFileFactory {
       return null;
     }
 
-    String fileFormat = FilenameUtils.getExtension(optionsFile.getFileName().toString());
-    var targetFile = getTargetFile(fileFormat);
+    var ext = PathUtils.toExtension(optionsFile);
+    var targetFile = getTargetFile(ext);
     try {
       fileFilter.copyFile(optionsFile.toFile(), targetFile.toFile(), true, project, Collections.emptyList(), false,
               StandardCharsets.UTF_8.name(), session);

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/FileDeployer.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/FileDeployer.java
@@ -15,7 +15,6 @@
  */
 package ch.ivyteam.ivy.maven.engine.deploy.dir;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
@@ -71,21 +69,20 @@ public class FileDeployer implements IvyDeployer {
   private void initDeployment() throws MojoExecutionException {
     try {
       if (deploymentOptionsFile != null) {
-        //var engineOption = deploymentFiles.getDeployCandidate().resolveSibling(deploymentOptionsFile.getName());
-        //Files.copy(deploymentOptionsFile.toPath(), engineOption);
-        File engineOption = new File(deploymentFiles.getDeployCandidate().getParent().toFile(), deploymentOptionsFile.getFileName().toString());
-        FileUtils.copyFile(deploymentOptionsFile.toFile(), engineOption);
+        var engineOption = deploymentFiles.getDeployCandidate().resolveSibling(deploymentOptionsFile.getFileName().toString());
+        Files.createDirectories(engineOption.getParent());
+        Files.copy(deploymentOptionsFile, engineOption);
       }
     } catch (IOException ex) {
-      throw new MojoExecutionException("Failed to initialize engine deployment, could not copy options file",
-              ex);
+      throw new MojoExecutionException("Failed to initialize engine deployment, could not copy options file", ex);
     }
   }
 
   private void copyDeployableToEngine() throws MojoExecutionException {
     try {
       log.info("Uploading file " + deployFile + " to " + targetDeployableFile);
-      FileUtils.copyFile(deployFile.toFile(), targetDeployableFile.toFile());
+      Files.createDirectories(targetDeployableFile.getParent());
+      Files.copy(deployFile, targetDeployableFile);
     } catch (IOException ex) {
       throw new MojoExecutionException("Upload of file '" + deployFile.getFileName().toString() + "' to engine failed.", ex);
     }

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/FileLogForwarder.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/FileLogForwarder.java
@@ -34,6 +34,7 @@ import org.apache.maven.plugin.logging.Log;
  * @since 6.1.0
  */
 class FileLogForwarder {
+
   private final Path engineLog;
   private final Log mavenLog;
 
@@ -102,5 +103,4 @@ class FileLogForwarder {
   static interface LogLineHandler {
     void handleLine(String newLogLine);
   }
-
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/util/PathUtils.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/util/PathUtils.java
@@ -1,0 +1,47 @@
+package ch.ivyteam.ivy.maven.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import org.apache.commons.lang3.StringUtils;
+
+public interface PathUtils {
+
+  public static String toExtension(Path path) {
+    return toExtension(path.getFileName().toString());
+  }
+
+  public static String toExtension(String path) {
+    return StringUtils.substringAfterLast(path, ".");
+  }
+
+  public static void delete(Path path) {
+    if (path == null) {
+      return;
+    }
+    if (!Files.exists(path)) {
+      return;
+    }
+
+    try (var stream = Files.walk(path)) {
+      stream.sorted(Comparator.reverseOrder())
+              .map(Path::toFile)
+              .forEach(File::delete);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  public static void clean(Path path) {
+    delete(path);
+    try {
+      Files.createDirectories(path);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+}

--- a/src/test/java/ch/ivyteam/ivy/maven/BaseEngineProjectMojoTest.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/BaseEngineProjectMojoTest.java
@@ -23,17 +23,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.junit.Rule;
 
 import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory;
 import ch.ivyteam.ivy.maven.util.ClasspathJar;
+import ch.ivyteam.ivy.maven.util.PathUtils;
 import ch.ivyteam.ivy.maven.util.SharedFile;
 
 public class BaseEngineProjectMojoTest {
@@ -73,13 +71,6 @@ public class BaseEngineProjectMojoTest {
     return defaultHomePath.toString();
   }
 
-  protected final static Collection<File> findFiles(Path dir, String fileExtension) {
-    if (!Files.exists(dir)) {
-      return Collections.emptyList();
-    }
-    return FileUtils.listFiles(dir.toFile(), new String[] {fileExtension}, true);
-  }
-
   private static final Path evalEngineDir(AbstractEngineMojo mojo) {
     return mojo.engineCacheDirectory.resolve(System.getProperty("ivy.engine.version", AbstractEngineMojo.DEFAULT_VERSION));
   }
@@ -107,7 +98,7 @@ public class BaseEngineProjectMojoTest {
       addTimestampToDownloadedEngine();
     }
 
-    private void deleteOutdatedEngine() throws IOException {
+    private void deleteOutdatedEngine() {
       var engineDir = getMojo().getRawEngineDirectory();
       if (engineDir == null || !Files.exists(engineDir)) {
         return;
@@ -116,7 +107,7 @@ public class BaseEngineProjectMojoTest {
       var timestampFile = engineDir.resolve(TIMESTAMP_FILE_NAME);
       if (isOlderThan24h(timestampFile.toFile())) {
         System.out.println("Deleting cached outdated engine.");
-        FileUtils.deleteDirectory(engineDir.toFile());
+        PathUtils.delete(engineDir);
       }
     }
 
@@ -181,7 +172,7 @@ public class BaseEngineProjectMojoTest {
     private void provideClasspathJar() throws IOException {
       var cpJar = new SharedFile(project).getEngineOSGiBootClasspathJar();
       new ClasspathJar(cpJar.toFile()).createFileEntries(EngineClassLoaderFactory
-              .getOsgiBootstrapClasspath(installUpToDateEngineRule.getMojo().getRawEngineDirectory().toFile()));
+              .getOsgiBootstrapClasspath(installUpToDateEngineRule.getMojo().getRawEngineDirectory()));
     }
 
     @Override

--- a/src/test/java/ch/ivyteam/ivy/maven/TestInstallEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestInstallEngineMojo.java
@@ -20,6 +20,7 @@ import static ch.ivyteam.ivy.maven.InstallEngineMojo.DEFAULT_ARCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -29,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.wink.client.MockHttpServer;
@@ -369,8 +369,10 @@ public class TestInstallEngineMojo {
       .isEqualTo("http://localhost/7.0.0/AxonIvyEngine7.0.0.46949_Linux_x86.zip");
   }
 
-  private String findLink(String html) throws MojoExecutionException, MalformedURLException, URISyntaxException {
-    return getUrlDownloader().findEngineDownloadUrl(IOUtils.toInputStream(html, StandardCharsets.UTF_8)).toExternalForm();
+  private String findLink(String html) throws MojoExecutionException, URISyntaxException, IOException {
+    try (var in = new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8))) {
+      return getUrlDownloader().findEngineDownloadUrl(in).toExternalForm();
+    }
   }
 
   @Test

--- a/src/test/java/ch/ivyteam/ivy/maven/TestShareEngineClasspathMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestShareEngineClasspathMojo.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +29,7 @@ import org.junit.Test;
 import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory.OsgiDir;
 
 public class TestShareEngineClasspathMojo {
+
   @Test
   public void engineClasspathIsSharedAsProperty() throws Exception {
     ShareEngineCoreClasspathMojo mojo = rule.getMojo();
@@ -38,7 +38,6 @@ public class TestShareEngineClasspathMojo {
             .isNullOrEmpty();
 
     mojo.execute();
-
     assertThat(getEngineClasspathProperty())
             .as("used classpath must be shared as property so that other mojos can access it")
             .contains("dummy-boot.jar");
@@ -68,11 +67,11 @@ public class TestShareEngineClasspathMojo {
       try {
         var engineDirectory = rule.getMojo().identifyAndGetEngineDirectory();
         var dummy = engineDirectory.resolve(OsgiDir.INSTALL_AREA).resolve(OsgiDir.LIB_BOOT).resolve("dummy-boot.jar");
-        FileUtils.touch(dummy.toFile());
+        Files.createDirectories(dummy.getParent());
+        Files.createFile(dummy);
       } catch (IOException | MojoExecutionException ex) {
         throw new RuntimeException("Cannot create server jars", ex);
       }
-
     }
   };
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/compile/TestCompileProjectMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/compile/TestCompileProjectMojo.java
@@ -18,15 +18,17 @@ package ch.ivyteam.ivy.maven.compile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
 import ch.ivyteam.ivy.maven.BaseEngineProjectMojoTest;
 import ch.ivyteam.ivy.maven.log.LogCollector;
+import ch.ivyteam.ivy.maven.util.PathUtils;
 
 public class TestCompileProjectMojo extends BaseEngineProjectMojoTest {
   private CompileTestProjectMojo testMojo;
@@ -50,8 +52,8 @@ public class TestCompileProjectMojo extends BaseEngineProjectMojoTest {
     var dataClassDir = mojo.project.getBasedir().toPath().resolve("src_dataClasses");
     var wsProcDir = mojo.project.getBasedir().toPath().resolve("src_wsproc");
     var classDir = mojo.project.getBasedir().toPath().resolve("classes");
-    FileUtils.cleanDirectory(wsProcDir.toFile());
-    FileUtils.cleanDirectory(dataClassDir.toFile());
+    PathUtils.clean(wsProcDir);
+    PathUtils.clean(dataClassDir);
 
     mojo.buildApplicationDirectory = Files.createTempDirectory("MyBuildApplication");
     mojo.execute();
@@ -70,6 +72,17 @@ public class TestCompileProjectMojo extends BaseEngineProjectMojoTest {
     assertThat(findFiles(classDir, "class"))
             .as("compiled classes must contain test resources as well")
             .hasSize(5);
+  }
+
+  private static List<Path> findFiles(Path dir, String fileExtension) throws IOException {
+    if (!Files.exists(dir)) {
+      return List.of();
+    }
+    try (var stream = Files.walk(dir)) {
+      return stream
+              .filter(p -> p.getFileName().toString().endsWith("." + fileExtension))
+              .toList();
+    }
   }
 
   @Test

--- a/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToEngineMojo.java
@@ -24,13 +24,13 @@ import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Rule;
 import org.junit.Test;
 
 import ch.ivyteam.ivy.maven.ProjectMojoRule;
 import ch.ivyteam.ivy.maven.engine.deploy.dir.DeploymentFiles;
+import ch.ivyteam.ivy.maven.util.PathUtils;
 
 public class TestDeployToEngineMojo {
 
@@ -180,7 +180,7 @@ public class TestDeployToEngineMojo {
     }
 
     private Path createEngineDir() throws IOException {
-      var engine = Path.of("target/myTestIvyEngine");
+      var engine = Path.of("target").resolve("myTestIvyEngine");
       var deploy = engine.resolve("deploy");
       Files.createDirectories(deploy);
       return engine.toAbsolutePath();
@@ -189,7 +189,7 @@ public class TestDeployToEngineMojo {
     @Override
     protected void after() {
       super.after();
-      FileUtils.deleteQuietly(getMojo().deployEngineDirectory.toFile());
+      PathUtils.delete(getMojo().deployEngineDirectory);
     }
   };
 

--- a/src/test/java/ch/ivyteam/ivy/maven/util/TestPathUtils.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/util/TestPathUtils.java
@@ -1,0 +1,95 @@
+package ch.ivyteam.ivy.maven.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+class TestPathUtils {
+
+  @Test
+  void toExtension_fromFilename() {
+    var path = Paths.get("test.pdf");
+    assertThat(PathUtils.toExtension(path)).isEqualTo("pdf");
+  }
+
+  @Test
+  void toExtension_fromPath() {
+    var path = Paths.get("/root/folder/test.pdf");
+    assertThat(PathUtils.toExtension(path)).isEqualTo("pdf");
+  }
+
+  @Test
+  void toExtension_missing() {
+    var path = Paths.get("test");
+    assertThat(PathUtils.toExtension(path)).isEmpty();
+  }
+
+  @Test
+  void toExtension_string_fromFilename() {
+    assertThat(PathUtils.toExtension("test.pdf")).isEqualTo("pdf");
+  }
+
+  @Test
+  void toExtension_string_fromPath() {
+    assertThat(PathUtils.toExtension("/root/folder/test.pdf")).isEqualTo("pdf");
+  }
+
+  @Test
+  void toExtension_string_missing() {
+    assertThat(PathUtils.toExtension("test")).isEmpty();
+  }
+
+  @Test
+  void delete_null() {
+    assertThatNoException().isThrownBy(() -> PathUtils.delete(null));
+  }
+
+  @Test
+  void delete_nonExisting() {
+    assertThatNoException().isThrownBy(() -> PathUtils.delete(Path.of("non-existing-directory")));
+  }
+
+  @Test
+  void delete_emptyDir(@TempDir Path tempDir) {
+    assertThat(tempDir).exists();
+
+    PathUtils.delete(tempDir);
+    assertThat(tempDir).doesNotExist();
+  }
+
+  @Test
+  void delete_file(@TempDir Path tempDir) throws IOException {
+    var file = tempDir.resolve("louis.txt");
+    Files.writeString(file, "müller");
+    assertThat(file).exists();
+
+    PathUtils.delete(file);
+    assertThat(file).doesNotExist();
+  }
+
+  @Test
+  void delete_notEmptyFolder(@TempDir Path tempDir) throws IOException {
+    var file = tempDir.resolve("louis.txt");
+    Files.writeString(file, "müller");
+    assertThat(file).exists();
+
+    var subFolder = tempDir.resolve("subFolder");
+    Files.createDirectory(subFolder);
+    assertThat(subFolder).exists();
+
+    var subFile = subFolder.resolve("chrischel.txt");
+    Files.writeString(subFile, "strebschel");
+    assertThat(subFile).exists();
+
+    PathUtils.delete(tempDir);
+    assertThat(tempDir).doesNotExist();
+  }
+}


### PR DESCRIPTION
Remove most of commons.io usages
    
    - java.nio provides good enough API's to to basic file operations
    - our code mostly uses java.nio now which makes it more simple
    - less dependencies to 3rd parties  which needs to be updated
    - FileAlternateObserver still left