### PR TITLE
Make two tests also working on windows

### DIFF
--- a/src/test/java/ch/ivyteam/ivy/maven/test/TestStartEngine.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/test/TestStartEngine.java
@@ -47,7 +47,8 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
     Executor startedProcess = null;
     try {
       startedProcess = mojo.startEngine();
-      assertThat(getProperty(EngineControl.Property.TEST_ENGINE_URL)).startsWith("http://")
+      assertThat(getProperty(EngineControl.Property.TEST_ENGINE_URL))
+              .startsWith("http://")
               .endsWith("/");
       assertThat(Path.of(getProperty(EngineControl.Property.TEST_ENGINE_LOG))).exists();
     } finally {
@@ -150,9 +151,10 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
     try {
       mojo.testEngine = TestEngineLocation.COPY_FROM_TEMPLATE;
       var engineDirTarget = mojo.getEngineDir(mojo.project);
-      assertThat(engineDirTarget.toString()).contains("/target/ivyEngine");
+      assertThat(engineDirTarget)
+        .endsWithRaw(Path.of("target").resolve("ivyEngine"))
+        .doesNotExist();
 
-      assertThat(engineDirTarget).doesNotExist();
       startedProcess = mojo.startEngine();
       assertThat(engineDirTarget).exists();
     } finally {
@@ -169,9 +171,9 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
     Executor startedProcess = null;
     try {
       var engineDirTarget = mojo.getEngineDir(mojo.project);
-      assertThat(engineDirTarget.toString()).contains("/target/ivyEngine");
-
-      assertThat(engineDirTarget).doesNotExist();
+      assertThat(engineDirTarget)
+        .endsWithRaw(Path.of("target").resolve("ivyEngine"))
+        .doesNotExist();
       assertThat(log.getWarnings().toString()).doesNotContain("Skipping copy");
 
       startedProcess = mojo.startEngine();


### PR DESCRIPTION
I wanted to add a windows ci pipeline. At the moment not possible because some tests are killing an Axon Ivy Engine with SIGKILL. This prevents the Axon Ivy Engine from stoping the bundled Elasticsearch Service, which than makes it impossible to clean the engine directory.

Seems that it is not possible with commons.cli to gracefully stop a service. I will need first to use the new Java Process API to manage the Axon Ivy Engine Process. This will also eliminate some maven warnings because the process is killed with SIGKILL.