### PR TITLE
document minimal required 3.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <description>Maven plugin for the automated building of Axon Ivy Projects. Referenced from the pom.xml of Axon Ivy Projects.</description>
   <url>https://github.com/axonivy/project-build-plugin</url>
   <prerequisites>
-    <maven>3.9.6</maven>
+    <maven>3.9.8</maven>
   </prerequisites>
   <licenses>
     <license>


### PR DESCRIPTION
otherwise goals using 'Path' parameter won't work on Windows and MacOS:

octopus and also @ivy-lmu were not able to build with 3.9.6 ... let's be fair and require 3.9.8