### PR TITLE
Search by default a LTS 12 engine

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java
@@ -42,7 +42,7 @@ public abstract class AbstractEngineMojo extends AbstractMojo {
    * requirements
    */
   protected static final String MINIMAL_COMPATIBLE_VERSION = "11.3.0";
-  protected static final String DEFAULT_VERSION = "11.4.0";
+  protected static final String DEFAULT_VERSION = "12.0.0";
 
   protected static final String ENGINE_DIRECTORY_PROPERTY = "ivy.engine.directory";
 


### PR DESCRIPTION
I'll raise the project-build-plugin later. But with this change our build integration should work again.