### PR TITLE
fix build: add ssh-agent for authorized pushes using GH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt update && \
-    apt install git gnupg2 gh -y
+    apt install git gnupg2 gh openssh-client -y


### PR DESCRIPTION
fix the release pipeline that fails at the end when instructed to push releases to github.

the ssh-agent is required as binary: see evidence that this works here https://jenkins.ivyteam.io/view/scrum-master/job/project-build-plugin_release/job/fixReleasePipe/