### PR TITLE
automate release-drafter publishing :newspaper_roll:  > R12

### DIFF
--- a/.github/workflows/draft-publisher.yml
+++ b/.github/workflows/draft-publisher.yml
@@ -1,0 +1,49 @@
+name: Release Publisher
+
+on: 
+  workflow_call:
+    inputs:
+      publish:
+        required: false
+        default: true
+        type: boolean
+      version:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish_release:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set version env
+        run: |
+          RELEASE_VERSION="${{ inputs.version }}";
+          if [ -z "$RELEASE_VERSION" ]; then
+            RELEASE_VERSION="${GITHUB_REF#refs/*/}"
+          fi;
+          echo RELEASE_VERSION=$RELEASE_VERSION >> $GITHUB_ENV
+
+          MINOR=${RELEASE_VERSION%.*}
+          MINOR=${MINOR#v}
+          TARGET=release/${MINOR}
+          if [[ "${GITHUB_REF#refs/*/}" -eq "master" ]]; then
+            TARGET="master"
+          fi
+          echo RELEASE_TARGET=$TARGET >> $GITHUB_ENV
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+          name: ${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION }}
+          version: ${{ env.RELEASE_VERSION }}
+          commitish: ${{ env.RELEASE_TARGET }}
+          publish: ${{ inputs.publish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "release/12.0"
       - uses: release-drafter/release-drafter@v6
         with:
-          # the drafter template lives on 'master', no need to add it to this release branch!
-          config-name: release-drafter-lts12.yml
+          config-name: release-drafter.yml
+          commitish: ${{ github.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-publisher.yml
+++ b/.github/workflows/tag-publisher.yml
@@ -1,0 +1,29 @@
+name: Tag Publisher
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: the tag-ref to release e.g. 'v12.0.0'
+      publish:
+        type: boolean
+        default: false
+        description: publish the drafted release as final version?
+    
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/draft-pub.yml
+    with:
+      version: ${{ inputs.tag }}
+      # The 'publish' input parameter is used to control whether the release should be published automatically.
+      # Uncomment and set to 'false' if you want to prevent the release from being published immediately.
+      publish: ${{ inputs.publish == null && true || inputs.publish }}

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ mvn versions:set -DnewVersion=10.0.0-SNAPSHOT -DprocessAllModules -DgenerateBack
 
 Wait until the maven central release is available: this may take several hours until it's fully distributed.
 
-- Publish the latest [draft release](https://github.com/axonivy/project-build-plugin/releases) do preserve the current changelog.
-    - Select the tag which was created for this release by the release-pipeline
-	- Verify that the title is correct
-	- Set the release as 'latest release'
-	- Publish it
+- Release-Drafter changes, if a new-release train was introduced:
+  
+  - on github UI (PR View):  flag the latest PR which was only merged to master with the label `major`.  
+    ... now release-drafter action runs should create new draft PRs for the new release; without overwriting the existing master drafts.
+
 - Raise project-build-plugin in other repos by triggering this [build](https://jenkins.ivyteam.io/view/jobs/job/github-repo-manager_raise-build-plugin-version/job/master/)
 	- Merge the generated PRs on GitHub
 - If you prepared for a new release train: update the default engine version in the [AbstractEngineMojo](src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java#L42)


### PR DESCRIPTION
- automatically publish new releases on new tags being created with semantic versions (v0.0.0)
- separate release/trains via 'commitish' without actually requiring multiple drafter templates