### PR TITLE
 XIVY-10541 Detect different plugin versions

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/validate/ValidateMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/validate/ValidateMojo.java
@@ -1,0 +1,71 @@
+package ch.ivyteam.ivy.maven.validate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+@Mojo(name = ValidateMojo.GOAL, requiresProject = true)
+public class ValidateMojo extends AbstractMojo {
+
+  public static final String GOAL = "validate";
+  protected static final String PLUGIN_GROUPID = "com.axonivy.ivy.ci";
+  protected static final String PLUGIN_ARTIFACTID = "project-build-plugin";
+
+  @Parameter(defaultValue = "${session}", readonly = true, required = true)
+  private MavenSession session;
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    validateConsistentPluginVersion(session.getAllProjects());
+  }
+
+  void validateConsistentPluginVersion(List<MavenProject> projects) throws MojoExecutionException {
+    var versionToProjectsMap = new HashMap<String, Set<MavenProject>>();
+    for (var project : projects) {
+      findProjectBuildPlugin(project.getBuild().getPlugins()).ifPresent(plugin -> {
+        var version = plugin.getVersion();
+        getLog().debug(PLUGIN_GROUPID + ":" + plugin.getArtifactId() + ":" + version + " configured in " + project);
+        var projectSet = versionToProjectsMap.computeIfAbsent(version, v -> new LinkedHashSet<>());
+        projectSet.add(project);
+      });
+    }
+    if (versionToProjectsMap.size() > 1) {
+      var versions = new ArrayList<>(versionToProjectsMap.keySet());
+      Collections.sort(versions);
+      var error = "Several versions of project-build-plugins are configured " + versions + ":\n";
+      error += versions.stream().map(v -> versionProjects(versionToProjectsMap, v)).collect(Collectors.joining("\n"));
+      getLog().error(error);
+      throw new MojoExecutionException("All project-build-plugins configured in one reactor must use the same version");
+    }
+  }
+
+  private Optional<Plugin> findProjectBuildPlugin(List<Plugin> plugins) {
+    return plugins.stream()
+        .filter(p -> PLUGIN_GROUPID.equals(p.getGroupId()) && PLUGIN_ARTIFACTID.equals(p.getArtifactId()))
+        .filter(p -> p.getVersion() != null) // Skip plug-ins that do not have a version
+        .findFirst();
+  }
+
+  private String versionProjects(Map<String, Set<MavenProject>> versionToProjectsMap, String version) {
+    return version + " -> [" +
+        versionToProjectsMap.get(version).stream()
+            .map(p -> p.getArtifactId())
+            .collect(Collectors.joining(", ")) +
+        "]";
+  }
+}

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -10,6 +10,7 @@
       <configuration>
         <phases>
           <clean>com.axonivy.ivy.ci:project-build-plugin:maven-dependency-cleanup</clean>
+          <validate>com.axonivy.ivy.ci:project-build-plugin:validate</validate>
           <initialize>com.axonivy.ivy.ci:project-build-plugin:installEngine</initialize>
           <process-resources>
             com.axonivy.ivy.ci:project-build-plugin:ivy-resources-properties,
@@ -38,6 +39,7 @@
       </implementation>
       <configuration>
         <phases>
+          <validate>com.axonivy.ivy.ci:project-build-plugin:validate</validate>
           <initialize>com.axonivy.ivy.ci:project-build-plugin:installEngine</initialize>
           <process-resources>
             com.axonivy.ivy.ci:project-build-plugin:ivy-resources-properties,

--- a/src/test/java/ch/ivyteam/ivy/maven/validate/TestValidateMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/validate/TestValidateMojo.java
@@ -1,0 +1,77 @@
+package ch.ivyteam.ivy.maven.validate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.junit.Rule;
+import org.junit.Test;
+
+import ch.ivyteam.ivy.maven.ProjectMojoRule;
+import ch.ivyteam.ivy.maven.log.LogCollector;
+
+
+public class TestValidateMojo {
+  private ValidateMojo mojo;
+
+  @Rule
+  public ProjectMojoRule<ValidateMojo> rule = new ProjectMojoRule<ValidateMojo>(
+          Path.of("src/test/resources/base"), ValidateMojo.GOAL) {
+    @Override
+    protected void before() throws Throwable {
+      super.before();
+      TestValidateMojo.this.mojo = getMojo();
+    }
+  };
+
+  @Test
+  public void samePluginVersions() throws Exception {
+    var log = new LogCollector();
+    rule.getMojo().setLog(log);
+    var p1 = createMavenProject("project1", "12.0.0");
+    var p2 = createMavenProject("project2", "12.0.0");
+    mojo.validateConsistentPluginVersion(List.of(p1, p2));
+    assertThat(log.getDebug()).hasSize(2);
+    assertThat(log.getDebug().get(0).toString())
+      .contains("com.axonivy.ivy.ci:project-build-plugin:12.0.0 configured in MavenProject: group:project1:12.0.0-SNAPSHOT");
+    assertThat(log.getDebug().get(1).toString())
+      .contains("com.axonivy.ivy.ci:project-build-plugin:12.0.0 configured in MavenProject: group:project2:12.0.0-SNAPSHOT");
+    assertThat(log.getErrors()).isEmpty();
+  }
+
+  @Test
+  public void differentPluginVersions() throws Exception {
+    var log = new LogCollector();
+    rule.getMojo().setLog(log);
+    var p1 = createMavenProject("project1", "12.0.0");
+    var p2 = createMavenProject("project2", "12.0.1");
+    assertThatThrownBy(() -> mojo.validateConsistentPluginVersion(List.of(p1, p2)))
+      .isInstanceOf(MojoExecutionException.class);
+    assertThat(log.getErrors()).hasSize(1);
+    assertThat(log.getErrors().get(0).toString())
+      .isEqualTo("""
+        Several versions of project-build-plugins are configured [12.0.0, 12.0.1]:
+        12.0.0 -> [project1]
+        12.0.1 -> [project2]""");
+  }
+
+  private MavenProject createMavenProject(String projectId, String version) {
+    var project = new MavenProject();
+    project.setGroupId("group");
+    project.setArtifactId(projectId);
+    project.setVersion("12.0.0-SNAPSHOT");
+    project.setFile(new File("src/test/resources/" + projectId));
+    var plugin = new Plugin();
+    plugin.setGroupId(ValidateMojo.PLUGIN_GROUPID);
+    plugin.setArtifactId(ValidateMojo.PLUGIN_ARTIFACTID);
+    plugin.setVersion(version);
+    project.getBuild().getPlugins().add(plugin);
+    return project;
+  }
+}


### PR DESCRIPTION
Tested with different project-build-plugin versions (12.0.1 and 12.0.2). Result in error message:
```log
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] workflow-demos                                                     [iar]
[INFO] workflow-demos-test                               [iar-integration-test]
[INFO] workflow-demos-product                                             [pom]
[INFO] workflow-modules                                                   [pom]
[INFO]
[INFO] ------------------< com.axonivy.demo:workflow-demos >-------------------
[INFO] Building workflow-demos 12.0.2-SNAPSHOT                            [1/4]
[INFO]   from workflow-demos/pom.xml
[INFO] --------------------------------[ iar ]---------------------------------
Downloading from central.snapshots: https://oss.sonatype.org/content/repositories/snapshots/org/apache/maven/plugins/maven-surefire-plugin/maven-metadata.xml
[INFO]
[INFO] --- ivy:12.0.2-SNAPSHOT:maven-dependency-cleanup (default-maven-dependency-cleanup) @ workflow-demos ---
[INFO] Deleting /Users/lli/GitWorkspace/market/demo-projects/workflow/workflow-demos/lib/mvn-deps
[INFO]
[INFO] --- clean:3.2.0:clean (default-clean) @ workflow-demos ---
[INFO] Deleting /Users/lli/GitWorkspace/market/demo-projects/workflow/workflow-demos/target
[INFO]
[INFO] --- ivy:12.0.2-SNAPSHOT:validate (default-validate) @ workflow-demos ---
[ERROR] Several versions of project-build-plugins are configured [12.0.1-SNAPSHOT, 12.0.2-SNAPSHOT]:
[ERROR] 12.0.1-SNAPSHOT:
[ERROR] 	MavenProject: com.axonivy.demo:workflow-demos-test:12.0.2-SNAPSHOT @ /Users/lli/GitWorkspace/market/demo-projects/workflow/workflow-demos-test/pom.xml
[ERROR] 12.0.2-SNAPSHOT:
[ERROR] 	MavenProject: com.axonivy.demo:workflow-demos:12.0.2-SNAPSHOT @ /Users/lli/GitWorkspace/market/demo-projects/workflow/workflow-demos/pom.xml
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for workflow-modules 12.0.2-SNAPSHOT:
[INFO]
[INFO] workflow-demos ..................................... FAILURE [  0.192 s]
[INFO] workflow-demos-test ................................ SKIPPED
[INFO] workflow-demos-product ............................. SKIPPED
[INFO] workflow-modules ................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.222 s
[INFO] Finished at: 2024-12-18T14:59:23+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.axonivy.ivy.ci:project-build-plugin:12.0.2-SNAPSHOT:validate (default-validate) on project workflow-demos: All project-build-plugins configured in one reactor must use the same version -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

Tested also with same project-build-plugin version but different engine versions (12.0.0 and 12.0.1). With this the build was successful.