### PR TITLE
XIVY-10541 Validate that only one project-build-plugin version is in the reactor

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/validate/ValidateMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/validate/ValidateMojo.java
@@ -1,0 +1,76 @@
+package ch.ivyteam.ivy.maven.validate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Validates that only one version of the project-build-plugin is active in one maven reactor.
+ *
+ * @since 10.0.17
+ */
+@Mojo(name = ValidateMojo.GOAL, requiresProject = true)
+public class ValidateMojo extends AbstractMojo {
+
+  public static final String GOAL = "validate";
+  protected static final String PLUGIN_GROUPID = "com.axonivy.ivy.ci";
+  protected static final String PLUGIN_ARTIFACTID = "project-build-plugin";
+
+  @Parameter(defaultValue = "${session}", readonly = true, required = true)
+  private MavenSession session;
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    validateConsistentPluginVersion(session.getAllProjects());
+  }
+
+  void validateConsistentPluginVersion(List<MavenProject> projects) throws MojoExecutionException {
+    var versionToProjectsMap = new HashMap<String, Set<MavenProject>>();
+    for (var project : projects) {
+      findProjectBuildPlugin(project.getBuild().getPlugins()).ifPresent(plugin -> {
+        var version = plugin.getVersion();
+        getLog().debug(PLUGIN_GROUPID + ":" + plugin.getArtifactId() + ":" + version + " configured in " + project);
+        var projectSet = versionToProjectsMap.computeIfAbsent(version, v -> new LinkedHashSet<>());
+        projectSet.add(project);
+      });
+    }
+    if (versionToProjectsMap.size() > 1) {
+      var versions = new ArrayList<>(versionToProjectsMap.keySet());
+      Collections.sort(versions);
+      var error = "Several versions of project-build-plugins are configured " + versions + ":\n";
+      error += versions.stream().map(v -> versionProjects(versionToProjectsMap, v)).collect(Collectors.joining("\n"));
+      getLog().error(error);
+      throw new MojoExecutionException("All project-build-plugins configured in one reactor must use the same version");
+    }
+  }
+
+  private Optional<Plugin> findProjectBuildPlugin(List<Plugin> plugins) {
+    return plugins.stream()
+        .filter(p -> PLUGIN_GROUPID.equals(p.getGroupId()) && PLUGIN_ARTIFACTID.equals(p.getArtifactId()))
+        .filter(p -> p.getVersion() != null) // Skip plug-ins that do not have a version
+        .findFirst();
+  }
+
+  private String versionProjects(Map<String, Set<MavenProject>> versionToProjectsMap, String version) {
+    return version + " -> [" +
+        versionToProjectsMap.get(version).stream()
+            .map(p -> p.getArtifactId())
+            .collect(Collectors.joining(", ")) +
+        "]";
+  }
+}

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -10,6 +10,7 @@
       <configuration>
         <phases>
           <clean>com.axonivy.ivy.ci:project-build-plugin:maven-dependency-cleanup</clean>
+          <validate>com.axonivy.ivy.ci:project-build-plugin:validate</validate>
           <initialize>com.axonivy.ivy.ci:project-build-plugin:installEngine</initialize>
           <process-resources>
             com.axonivy.ivy.ci:project-build-plugin:ivy-resources-properties,
@@ -38,6 +39,7 @@
       </implementation>
       <configuration>
         <phases>
+          <validate>com.axonivy.ivy.ci:project-build-plugin:validate</validate>
           <initialize>com.axonivy.ivy.ci:project-build-plugin:installEngine</initialize>
           <process-resources>
             com.axonivy.ivy.ci:project-build-plugin:ivy-resources-properties,

--- a/src/site/apt/lifecycle.apt.vm
+++ b/src/site/apt/lifecycle.apt.vm
@@ -7,6 +7,8 @@ iar Lifecycle
 *--------*---------*
  clean             | ${project.groupId}:${project.artifactId}:{{{./maven-dependency-cleanup-mojo.html}maven-dependency-cleanup}}
 *--------*---------*
+ validate          | ${project.groupId}:${project.artifactId}:{{{./validate-mojo.html}validate}}
+*--------*---------*
  initialize        | ${project.groupId}:${project.artifactId}:{{{./installEngine-mojo.html}installEngine}}
 *--------*---------*
  process-resources | ${project.groupId}:${project.artifactId}:{{{./ivy-resources-properties-mojo.html}ivy-resources-properties}}\

--- a/src/test/java/ch/ivyteam/ivy/maven/validate/TestValidateMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/validate/TestValidateMojo.java
@@ -1,0 +1,76 @@
+package ch.ivyteam.ivy.maven.validate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.junit.Rule;
+import org.junit.Test;
+
+import ch.ivyteam.ivy.maven.ProjectMojoRule;
+import ch.ivyteam.ivy.maven.log.LogCollector;
+
+
+public class TestValidateMojo {
+  private ValidateMojo mojo;
+
+  @Rule
+  public ProjectMojoRule<ValidateMojo> rule = new ProjectMojoRule<ValidateMojo>(
+         new File("src/test/resources/base"), ValidateMojo.GOAL) {
+    @Override
+    protected void before() throws Throwable {
+      super.before();
+      TestValidateMojo.this.mojo = getMojo();
+    }
+  };
+
+  @Test
+  public void samePluginVersions() throws Exception {
+    var log = new LogCollector();
+    rule.getMojo().setLog(log);
+    var p1 = createMavenProject("project1", "10.0.0");
+    var p2 = createMavenProject("project2", "10.0.0");
+    mojo.validateConsistentPluginVersion(List.of(p1, p2));
+    assertThat(log.getDebug()).hasSize(2);
+    assertThat(log.getDebug().get(0).toString())
+      .contains("com.axonivy.ivy.ci:project-build-plugin:10.0.0 configured in MavenProject: group:project1:10.0.0-SNAPSHOT");
+    assertThat(log.getDebug().get(1).toString())
+      .contains("com.axonivy.ivy.ci:project-build-plugin:10.0.0 configured in MavenProject: group:project2:10.0.0-SNAPSHOT");
+    assertThat(log.getErrors()).isEmpty();
+  }
+
+  @Test
+  public void differentPluginVersions() throws Exception {
+    var log = new LogCollector();
+    rule.getMojo().setLog(log);
+    var p1 = createMavenProject("project1", "10.0.0");
+    var p2 = createMavenProject("project2", "10.0.1");
+    assertThatThrownBy(() -> mojo.validateConsistentPluginVersion(List.of(p1, p2)))
+      .isInstanceOf(MojoExecutionException.class);
+    assertThat(log.getErrors()).hasSize(1);
+    assertThat(log.getErrors().get(0).toString())
+      .isEqualTo("""
+        Several versions of project-build-plugins are configured [10.0.0, 10.0.1]:
+        10.0.0 -> [project1]
+        10.0.1 -> [project2]""");
+  }
+
+  private MavenProject createMavenProject(String projectId, String version) {
+    var project = new MavenProject();
+    project.setGroupId("group");
+    project.setArtifactId(projectId);
+    project.setVersion("10.0.0-SNAPSHOT");
+    project.setFile(new File("src/test/resources/" + projectId));
+    var plugin = new Plugin();
+    plugin.setGroupId(ValidateMojo.PLUGIN_GROUPID);
+    plugin.setArtifactId(ValidateMojo.PLUGIN_ARTIFACTID);
+    plugin.setVersion(version);
+    project.getBuild().getPlugins().add(plugin);
+    return project;
+  }
+}


### PR DESCRIPTION
demo-projects build output:
```
[INFO] --- ivy:10.0.17-SNAPSHOT:validate (default-validate) @ workflow-demos ---
[ERROR] Several versions of project-build-plugins are configured [10.0.17-SNAPSHOT, 10.0.6]:
10.0.17-SNAPSHOT -> [workflow-demos]
10.0.6 -> [html-dialog-demos, html-dialog-demos-test, error-handling-demos, quick-start-tutorial, rule-engine-demos, rule-engine-demos-test, workflow-demos-test, connectivity-demos, connectivity-demos-test]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for ivy-project-modules 10.0.3-SNAPSHOT:
[INFO]
[INFO] html-dialog-demos .................................. SUCCESS [  4.083 s]
[INFO] html-dialog-demos-test ............................. SUCCESS [  0.756 s]
[INFO] html-dialog-demos-product .......................... SUCCESS [  0.125 s]
[INFO] html-dialog-modules ................................ SUCCESS [  0.001 s]
[INFO] error-handling-demos ............................... SUCCESS [  0.385 s]
[INFO] error-handling-demos-product ....................... SUCCESS [  0.005 s]
[INFO] error-handling-modules ............................. SUCCESS [  0.000 s]
[INFO] quick-start-tutorial ............................... SUCCESS [  0.210 s]
[INFO] quick-start-tutorial-product ....................... SUCCESS [  0.003 s]
[INFO] quick-start-tutorial-modules ....................... SUCCESS [  0.001 s]
[INFO] rule-engine-demos .................................. SUCCESS [  0.256 s]
[INFO] rule-engine-demos-test ............................. SUCCESS [  0.223 s]
[INFO] rule-engine-demos-product .......................... SUCCESS [  0.005 s]
[INFO] rule-engine-modules ................................ SUCCESS [  0.000 s]
[INFO] workflow-demos ..................................... FAILURE [  0.020 s]
[INFO] workflow-demos-test ................................ SKIPPED
[INFO] workflow-demos-product ............................. SKIPPED
[INFO] workflow-modules ................................... SKIPPED
[INFO] connectivity-demos ................................. SKIPPED
[INFO] connectivity-demos-test ............................ SKIPPED
[INFO] connectivity-demos-product ......................... SKIPPED
[INFO] connectivity-modules ............................... SKIPPED
[INFO] ivy-demos-app ...................................... SKIPPED
[INFO] ivy-demos-app-product .............................. SKIPPED
[INFO] demos-app-modules .................................. SKIPPED
[INFO] ivy-project-modules ................................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.047 s
[INFO] Finished at: 2024-12-19T10:09:33+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.axonivy.ivy.ci:project-build-plugin:10.0.17-SNAPSHOT:validate (default-validate) on project workflow-demos: All project-build-plugins configured in one reactor must use the same version -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :workflow-demos
```