### PR TITLE
Format and Clean up Java source code as defined in ADR-029

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/AbstractEngineMojo.java
@@ -87,9 +87,7 @@ public abstract class AbstractEngineMojo extends AbstractMojo {
   /** testing only: avoid restriction to minimal version! */
   boolean restrictVersionToMinimalCompatible = true;
 
-  public AbstractEngineMojo() {
-    super();
-  }
+  public AbstractEngineMojo() {}
 
   /**
    * <b style="color:red">Caution</b>: normally you should favor
@@ -169,14 +167,14 @@ public abstract class AbstractEngineMojo extends AbstractMojo {
   }
 
   private VersionRange restrictToMinimalCompatible(VersionRange ivyVersionRange)
-          throws InvalidVersionSpecificationException, MojoExecutionException {
+      throws InvalidVersionSpecificationException, MojoExecutionException {
     VersionRange minimalCompatibleVersionRange = VersionRange
-            .createFromVersionSpec("[" + AbstractEngineMojo.MINIMAL_COMPATIBLE_VERSION + ",)");
+        .createFromVersionSpec("[" + AbstractEngineMojo.MINIMAL_COMPATIBLE_VERSION + ",)");
     VersionRange restrictedIvyVersionRange = ivyVersionRange.restrict(minimalCompatibleVersionRange);
     if (!restrictedIvyVersionRange.hasRestrictions()) {
       throw new MojoExecutionException(
-              "The ivyVersion '" + ivyVersion + "' is lower than the minimal compatible version"
-                      + " '" + MINIMAL_COMPATIBLE_VERSION + "'.");
+          "The ivyVersion '" + ivyVersion + "' is lower than the minimal compatible version"
+              + " '" + MINIMAL_COMPATIBLE_VERSION + "'.");
     }
     return restrictedIvyVersionRange;
   }

--- a/src/main/java/ch/ivyteam/ivy/maven/IarPackagingMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/IarPackagingMojo.java
@@ -47,15 +47,14 @@ import ch.ivyteam.ivy.maven.util.FileSetConverter;
 public class IarPackagingMojo extends AbstractMojo {
   public static final String GOAL = "pack-iar";
 
-  public static interface Defaults {
-    String[] INCLUDES = new String[] {"**/*"};
-    String[] EXCLUDES = new String[] {"target/"};
-    String[] TARGET_INCLUDES = new String[] {
-      "target/classes/**/*",
-      "target/src_hd/**/*"
+  public interface Defaults {
+    String[] INCLUDES = {"**/*"};
+    String[] EXCLUDES = {"target/"};
+    String[] TARGET_INCLUDES = {
+        "target/classes/**/*",
+        "target/src_hd/**/*"
     };
   }
-
 
   @Parameter(property = "project", required = true, readonly = true)
   MavenProject project;
@@ -68,8 +67,8 @@ public class IarPackagingMojo extends AbstractMojo {
    * Sample:
    * <pre>
    * <code>&lt;iarExcludes&gt;
-   *    &lt;iarExclude&gt;target/com/acme/scret/*&lt;/iarExclude&gt;
-   *    &lt;iarExclude&gt;src/&lt;/iarExclude&gt;
+   * &nbsp;&nbsp;&lt;iarExclude&gt;target/com/acme/scret/*&lt;/iarExclude&gt;
+   * &nbsp;&nbsp;&lt;iarExclude&gt;src/&lt;/iarExclude&gt;
    * &lt;/iarExcludes&gt;</code>
    * </pre>
    */
@@ -84,13 +83,13 @@ public class IarPackagingMojo extends AbstractMojo {
    * See {@link ch.ivyteam.ivy.maven.IarPackagingMojo.Defaults#TARGET_INCLUDES}.
    *
    * <pre>
-   * <code>&lt;iarFileSets&gt;
-   *    &lt;iarFileSet&gt;
-   *        &lt;includes&gt;
-   *            &lt;include&gt;**&#47;*&lt;/include&gt;
-   *        &lt;/includes&gt;
-   *    &lt;/iarFileSet&gt;
-   *&lt;/iarFileSets&gt;</code>
+   * &lt;iarFileSets&gt;
+   * &nbsp;&nbsp;&lt;iarFileSet&gt;
+   * &nbsp;&nbsp;&nbsp;&nbsp;&lt;includes&gt;
+   * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;include&gt;**&#47;*&lt;/include&gt;
+   * &nbsp;&nbsp;&nbsp;&nbsp;&lt;/includes&gt;
+   * &nbsp;&nbsp;&lt;/iarFileSet&gt;
+   * &lt;/iarFileSets&gt;
    * </pre>
    */
   @Parameter

--- a/src/main/java/ch/ivyteam/ivy/maven/InstallEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/InstallEngineMojo.java
@@ -81,11 +81,11 @@ public class InstallEngineMojo extends AbstractEngineMojo {
    * </p>
    *
    * <pre>
-   *    groupId=com.axonivy.ivy
-   *    artifactId=engine
-   *    version=!ivyVersion! (e.g. 7.4.0)
-   *    classifier=!osArchitecture! (e.g. Slim_All_x64)
-   *    extension=zip
+   * groupId=com.axonivy.ivy
+   * artifactId=engine
+   * version=!ivyVersion! (e.g. 7.4.0)
+   * classifier=!osArchitecture! (e.g. Slim_All_x64)
+   * extension=zip
    * </pre>
    *
    * @since 7.4
@@ -185,7 +185,7 @@ public class InstallEngineMojo extends AbstractEngineMojo {
 
   private void handleWrongIvyVersion(ArtifactVersion installedEngineVersion) throws MojoExecutionException {
     getLog().info("Installed engine in '" + getRawEngineDirectory() + "' has version '"
-            + installedEngineVersion + "' instead of expected '" + ivyVersion + "'");
+        + installedEngineVersion + "' instead of expected '" + ivyVersion + "'");
     boolean cleanEngineDir = installedEngineVersion != null;
     downloadAndInstallEngine(cleanEngineDir);
   }
@@ -223,30 +223,30 @@ public class InstallEngineMojo extends AbstractEngineMojo {
       ArtifactVersion installedEngineVersion = getInstalledEngineVersion(getRawEngineDirectory());
       if (installedEngineVersion == null) {
         throw new MojoExecutionException(
-                "Can not determine installed engine version in directory '" + getRawEngineDirectory() + "'. "
-                        + "Possibly a non-OSGi engine.");
+            "Can not determine installed engine version in directory '" + getRawEngineDirectory() + "'. "
+                + "Possibly a non-OSGi engine.");
       }
       if (!getIvyVersionRange().containsVersion(installedEngineVersion)) {
         throw new MojoExecutionException("Automatic installation of an ivyEngine failed. "
-                + "Downloaded version is '" + installedEngineVersion + "' but expecting '" + ivyVersion
-                + "'.");
+            + "Downloaded version is '" + installedEngineVersion + "' but expecting '" + ivyVersion
+            + "'.");
       }
     } else {
       throw new MojoExecutionException("Aborting class generation as no valid ivy Engine is available! "
-              + "Use the 'autoInstallEngine' parameter for an automatic installation.");
+          + "Use the 'autoInstallEngine' parameter for an automatic installation.");
     }
   }
 
   public EngineDownloader getDownloader() throws MojoExecutionException {
     if (downloadUsingMaven) {
       return new MavenEngineDownloader(getLog(), ivyVersion, osArchitecture, pluginRepositories,
-              repositorySystem, repositorySession);
+          repositorySystem, repositorySession);
     }
 
     @SuppressWarnings("deprecation")
     ProxyInfoProvider proxies = wagonManager::getProxy;
     return new URLEngineDownloader(engineDownloadUrl, engineListPageUrl, osArchitecture, ivyVersion,
-            getIvyVersionRange(), getLog(), getDownloadDirectory(), proxies);
+        getIvyVersionRange(), getLog(), getDownloadDirectory(), proxies);
   }
 
   static String ivyEngineVersionOfZip(String engineZipFileName) {

--- a/src/main/java/ch/ivyteam/ivy/maven/SetupIvyResourcesPropertiesMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/SetupIvyResourcesPropertiesMojo.java
@@ -50,7 +50,7 @@ public class SetupIvyResourcesPropertiesMojo extends AbstractEngineMojo {
     var sourceEncoding = properties.get(PROJECT_BUILD_SOURCEENCODING);
     if (sourceEncoding != null) {
       getLog().info("'" + PROJECT_BUILD_SOURCEENCODING + "' is already set to '" +
-              sourceEncoding + "', so it will not be overwritten to UTF-8");
+          sourceEncoding + "', so it will not be overwritten to UTF-8");
       return;
     }
     getLog().info("Set '" + PROJECT_BUILD_SOURCEENCODING + "' to UTF-8");

--- a/src/main/java/ch/ivyteam/ivy/maven/compile/AbstractEngineInstanceMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/AbstractEngineInstanceMojo.java
@@ -60,9 +60,7 @@ public abstract class AbstractEngineInstanceMojo extends AbstractEngineMojo {
 
   private static MavenProjectBuilderProxy builder;
 
-  public AbstractEngineInstanceMojo() {
-    super();
-  }
+  public AbstractEngineInstanceMojo() {}
 
   @Override
   public final void execute() throws MojoExecutionException, MojoFailureException {
@@ -84,11 +82,11 @@ public abstract class AbstractEngineInstanceMojo extends AbstractEngineMojo {
     var engineDir = identifyAndGetEngineDirectory();
     if (builder == null) {
       builder = new MavenProjectBuilderProxy(
-              classLoaderFactory,
-              toFile(buildApplicationDirectory),
-              toFile(engineDir),
-              getLog(),
-              timeoutEngineStartInSeconds);
+          classLoaderFactory,
+          toFile(buildApplicationDirectory),
+          toFile(engineDir),
+          getLog(),
+          timeoutEngineStartInSeconds);
     }
     classLoaderFactory.writeEngineClasspathJar(engineDir);
     // share engine directory as property for custom follow up plugins:
@@ -104,7 +102,7 @@ public abstract class AbstractEngineInstanceMojo extends AbstractEngineMojo {
 
   public final EngineClassLoaderFactory getEngineClassloaderFactory() {
     MavenContext context = new EngineClassLoaderFactory.MavenContext(
-            repository, localRepository, project, getLog());
+        repository, localRepository, project, getLog());
     return new EngineClassLoaderFactory(context);
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/compile/AbstractProjectCompileMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/AbstractProjectCompileMojo.java
@@ -79,7 +79,7 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineInstanceM
   protected Map<String, Object> getOptions() {
     Map<String, Object> options = new HashMap<>();
     options.put(MavenProjectBuilderProxy.Options.TEST_SOURCE_DIR,
-            project.getBuild().getTestSourceDirectory());
+        project.getBuild().getTestSourceDirectory());
     options.put(MavenProjectBuilderProxy.Options.COMPILE_CLASSPATH, getDependencyClasspath());
     options.put(MavenProjectBuilderProxy.Options.SOURCE_ENCODING, encoding);
     options.put(MavenProjectBuilderProxy.Options.WARNINGS_ENABLED, Boolean.toString(compilerWarnings));
@@ -90,9 +90,9 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineInstanceM
 
   private String getDependencyClasspath() {
     return StringUtils.join(getDependencies("jar").stream()
-            .map(Path::toFile)
-            .map(jar -> jar.getAbsolutePath())
-            .collect(Collectors.toList()), File.pathSeparatorChar);
+        .map(Path::toFile)
+        .map(File::getAbsolutePath)
+        .collect(Collectors.toList()), File.pathSeparatorChar);
   }
 
   private File getCompilerSettings() {
@@ -100,7 +100,7 @@ public abstract class AbstractProjectCompileMojo extends AbstractEngineInstanceM
       return compilerSettings.toFile();
     } else if (compilerWarnings) {
       getLog().warn("Could not locate compiler settings file: " + compilerSettings
-              + " continuing with default compiler settings");
+          + " continuing with default compiler settings");
     }
     return null;
   }

--- a/src/main/java/ch/ivyteam/ivy/maven/compile/CompileTestProjectMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/CompileTestProjectMojo.java
@@ -64,7 +64,6 @@ public class CompileTestProjectMojo extends AbstractProjectCompileMojo {
     if (!Files.exists(iarJarClasspath)) {
       return Collections.emptyList();
     }
-    var iarJars = new ClasspathJar(iarJarClasspath).getFiles();
-    return iarJars;
+    return new ClasspathJar(iarJarClasspath).getFiles();
   }
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/deploy/AbstractDeployMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/deploy/AbstractDeployMojo.java
@@ -156,9 +156,9 @@ public abstract class AbstractDeployMojo extends AbstractIntegrationTestMojo {
    *
    * <pre>
    * <code>deployTestUsers: auto
-   *target:
-   *  version: RELEASED
-   *  state: ACTIVE_AND_RELEASED</code>
+   * target:
+   * &nbsp;&nbsp;version: RELEASED
+   * &nbsp;&nbsp;state: ACTIVE_AND_RELEASED</code>
    * </pre>
    *
    * <p>
@@ -168,9 +168,9 @@ public abstract class AbstractDeployMojo extends AbstractIntegrationTestMojo {
    *
    * <pre>
    * <code>deployTestUsers: ${ivy.deploy.test.users}
-   *target:
-   *  version: AUTO
-   *  state: ${ivy.deploy.target.state}</code>
+   * target:
+   * &nbsp;&nbsp;version: AUTO
+   * &nbsp;&nbsp;state: ${ivy.deploy.target.state}</code>
    * </pre>
    *
    * <p>
@@ -211,9 +211,7 @@ public abstract class AbstractDeployMojo extends AbstractIntegrationTestMojo {
   @Parameter(property = "ivy.deploy.engine.app")
   String deployToEngineApplication;
 
-  public AbstractDeployMojo() {
-    super();
-  }
+  public AbstractDeployMojo() {}
 
   protected final boolean checkSkip() {
     if (skipDeploy) {
@@ -228,7 +226,7 @@ public abstract class AbstractDeployMojo extends AbstractIntegrationTestMojo {
   }
 
   protected final Path createDeployOptionsFile(DeploymentOptionsFileFactory optionsFileFactory)
-          throws MojoExecutionException {
+      throws MojoExecutionException {
     if (deployOptionsFile != null) {
       return optionsFileFactory.createFromTemplate(deployOptionsFile, project, session, fileFilter);
     }
@@ -255,7 +253,7 @@ public abstract class AbstractDeployMojo extends AbstractIntegrationTestMojo {
   }
 
   protected final void deployToDirectory(Path resolvedOptionsFile, Path deployDir)
-          throws MojoExecutionException {
+      throws MojoExecutionException {
     var targetDeployableFile = createTargetDeployableFile(deployDir);
     String deployablePath = deployDir.relativize(targetDeployableFile).toString();
     IvyDeployer deployer = new FileDeployer(deployDir, resolvedOptionsFile, deployTimeoutInSeconds, deployFile, targetDeployableFile);
@@ -264,7 +262,7 @@ public abstract class AbstractDeployMojo extends AbstractIntegrationTestMojo {
 
   private final Path createTargetDeployableFile(Path deployDir) {
     return deployDir
-            .resolve(deployToEngineApplication)
-            .resolve(deployFile.getFileName().toString());
+        .resolve(deployToEngineApplication)
+        .resolve(deployFile.getFileName().toString());
   }
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToEngineMojo.java
@@ -135,7 +135,7 @@ public class DeployToEngineMojo extends AbstractDeployMojo {
     }
     if (StringUtils.isEmpty(deployToEngineApplication)) {
       throw new MojoExecutionException(
-              "The parameter 'deployToEngineApplication' for goal " + GOAL + " is missing.");
+          "The parameter 'deployToEngineApplication' for goal " + GOAL + " is missing.");
     }
 
     var resolvedOptionsFile = createDeployOptionsFile(new DeploymentOptionsFileFactory(deployFile));
@@ -154,8 +154,8 @@ public class DeployToEngineMojo extends AbstractDeployMojo {
       deployToRestService(resolvedOptionsFile);
     } else {
       getLog().warn("Invalid deploy method  " + deployMethod
-              + " configured in parameter deployMethod (Supported values are " + DeployMethod.DIRECTORY + ", "
-              + DeployMethod.HTTP + ")");
+          + " configured in parameter deployMethod (Supported values are " + DeployMethod.DIRECTORY + ", "
+          + DeployMethod.HTTP + ")");
     }
   }
 
@@ -163,13 +163,13 @@ public class DeployToEngineMojo extends AbstractDeployMojo {
     var deployDir = getDeployDirectory();
     if (deployEngineDirectory == null) {
       getLog().warn("Skipping deployment, target engine could not be evaluated." +
-              "Please configure an existing engine to deploy to with argument <deployEngineDirectory>.");
+          "Please configure an existing engine to deploy to with argument <deployEngineDirectory>.");
       return;
     }
 
     if (!Files.exists(deployDir)) {
       getLog().warn("Skipping deployment to engine '" + deployEngineDirectory + "'. The directory '"
-              + deployDir + "' does not exist.");
+          + deployDir + "' does not exist.");
       return;
     }
     checkDirParams();
@@ -182,7 +182,7 @@ public class DeployToEngineMojo extends AbstractDeployMojo {
     Server server = session.getSettings().getServer(deployServerId);
     if (server == null) {
       getLog().warn("Can not load credentials from settings.xml because server '" + deployServerId
-              + "' is not definied. Try to deploy with default username, password");
+          + "' is not definied. Try to deploy with default username, password");
     }
     var httpDeployer = new HttpDeployer(secDispatcher, server, deployEngineUrl, deployToEngineApplication, deployFile, resolvedOptionsFile);
     httpDeployer.deploy(getLog());
@@ -194,9 +194,9 @@ public class DeployToEngineMojo extends AbstractDeployMojo {
     }
     Object defaultDeployEngineDirectory = project.getProperties().get(ENGINE_DIRECTORY_PROPERTY);
     if (deployEngineDirectory != null
-            && !deployEngineDirectory.toFile().getPath().equals(defaultDeployEngineDirectory)) {
+        && !deployEngineDirectory.toFile().getPath().equals(defaultDeployEngineDirectory)) {
       logParameterIgnoredByMethod("deployEngineDirectory", deployEngineDirectory.toFile().getPath(),
-              DeployMethod.HTTP);
+          DeployMethod.HTTP);
     }
   }
 
@@ -211,7 +211,7 @@ public class DeployToEngineMojo extends AbstractDeployMojo {
 
   private void logParameterIgnoredByMethod(String parameter, String value, String method) {
     getLog().warn("Parameter " + parameter + " is set to " + value + " but will be ignored by " + method
-            + " deployment.");
+        + " deployment.");
   }
 
   private Path getDeployDirectory() throws MojoExecutionException {
@@ -224,14 +224,14 @@ public class DeployToEngineMojo extends AbstractDeployMojo {
     return deployEngineDirectory.resolve(deployDirectory);
   }
 
-  public static interface DefaultDeployOptions {
+  public interface DefaultDeployOptions {
     String VERSION_AUTO = "AUTO";
     String STATE_ACTIVE_AND_RELEASED = "ACTIVE_AND_RELEASED";
     String FILE_FORMAT_AUTO = "AUTO";
     String DEPLOY_TEST_USERS = "AUTO";
   }
 
-  public static interface DeployMethod {
+  public interface DeployMethod {
     String DIRECTORY = "DIRECTORY";
     String HTTP = "HTTP";
   }

--- a/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToTestEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToTestEngineMojo.java
@@ -52,7 +52,7 @@ import ch.ivyteam.ivy.maven.util.MavenRuntime;
 public class DeployToTestEngineMojo extends AbstractDeployMojo {
   public static final String TEST_GOAL = "deploy-to-test-engine";
 
-  public static interface Property {
+  public interface Property {
     String TEST_ENGINE_APP = "test.engine.app";
   }
 
@@ -86,7 +86,7 @@ public class DeployToTestEngineMojo extends AbstractDeployMojo {
     props.set(Property.TEST_ENGINE_APP, deployToEngineApplication);
 
     boolean isDefaultFile = deployFile.getFileName()
-            .endsWith(project.getArtifactId() + "-" + project.getVersion() + ".iar");
+        .endsWith(project.getArtifactId() + "-" + project.getVersion() + ".iar");
     if (isDefaultFile && deployDepsAsApp) {
       provideDepsAsAppZip();
     }
@@ -132,7 +132,7 @@ public class DeployToTestEngineMojo extends AbstractDeployMojo {
         }
       } else {
         getLog().warn("Can not add dependency to app zip '" + dep + "'. \n "
-                + "Dependency type is neither an IAR nor a reactor project.");
+            + "Dependency type is neither an IAR nor a reactor project.");
       }
     }
     appZipper.createArchive();
@@ -145,7 +145,7 @@ public class DeployToTestEngineMojo extends AbstractDeployMojo {
       return Optional.empty();
     }
     try (Stream<Path> find = Files.find(target, 1,
-            (p, attr) -> p.getFileName().toString().endsWith(".iar"))) {
+        (p, attr) -> p.getFileName().toString().endsWith(".iar"))) {
       return find.findAny();
     }
   }

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
@@ -57,15 +57,15 @@ public class EngineClassLoaderFactory {
   private static final String SLF4J_VERSION = "2.0.13";
 
   private static final List<String> ENGINE_LIB_DIRECTORIES = Arrays.asList(
-          OsgiDir.INSTALL_AREA + "/" + OsgiDir.LIB_BOOT,
-          OsgiDir.PLUGINS,
-          OsgiDir.INSTALL_AREA + "/configuration/org.eclipse.osgi", // unpacked
-                                                                    // jars from
-                                                                    // OSGI
-                                                                    // bundles
-          "webapps" + File.separator + "ivy" + File.separator + "WEB-INF" + File.separator + "lib");
+      OsgiDir.INSTALL_AREA + "/" + OsgiDir.LIB_BOOT,
+      OsgiDir.PLUGINS,
+      OsgiDir.INSTALL_AREA + "/configuration/org.eclipse.osgi", // unpacked
+                                                                // jars from
+                                                                // OSGI
+                                                                // bundles
+      "webapps" + File.separator + "ivy" + File.separator + "WEB-INF" + File.separator + "lib");
 
-  private MavenContext maven;
+  private final MavenContext maven;
 
   public EngineClassLoaderFactory(MavenContext mavenContext) {
     this.maven = mavenContext;
@@ -85,9 +85,9 @@ public class EngineClassLoaderFactory {
 
   public List<File> getSlf4jJars() {
     return List.of(
-            maven.getJar("org.slf4j", "slf4j-api", SLF4J_VERSION),
-            maven.getJar("org.slf4j", "slf4j-simple", SLF4J_VERSION),
-            maven.getJar("org.slf4j", "log4j-over-slf4j", SLF4J_VERSION));
+        maven.getJar("org.slf4j", "slf4j-api", SLF4J_VERSION),
+        maven.getJar("org.slf4j", "slf4j-simple", SLF4J_VERSION),
+        maven.getJar("org.slf4j", "log4j-over-slf4j", SLF4J_VERSION));
   }
 
   public static List<File> getOsgiBootstrapClasspath(Path engineDirectory) {
@@ -104,9 +104,9 @@ public class EngineClassLoaderFactory {
     if (Files.isDirectory(dir)) {
       try (var stream = Files.list(dir)) {
         var files = stream
-                .filter(filter)
-                .map(p -> p.toFile())
-                .toList();
+            .filter(filter)
+            .map(Path::toFile)
+            .toList();
         classPathFiles.addAll(files);
       } catch (IOException ex) {
         throw new RuntimeException(ex);
@@ -127,9 +127,9 @@ public class EngineClassLoaderFactory {
       }
       try (var walker = Files.walk(jarDir)) {
         var jars = walker
-          .filter(p -> p.getFileName().toString().endsWith(".jar"))
-          .map(p -> p.toFile())
-          .toList();
+            .filter(p -> p.getFileName().toString().endsWith(".jar"))
+            .map(Path::toFile)
+            .toList();
         classPathFiles.addAll(jars);
       } catch (IOException ex) {
         throw new RuntimeException(ex);
@@ -164,7 +164,7 @@ public class EngineClassLoaderFactory {
     private final Log log;
 
     public MavenContext(RepositorySystem repoSystem, ArtifactRepository localRepository, MavenProject project,
-            Log log) {
+        Log log) {
       this.repoSystem = repoSystem;
       this.localRepository = localRepository;
       this.project = project;

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineControl.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineControl.java
@@ -47,7 +47,7 @@ import ch.ivyteam.ivy.maven.test.StartTestEngineMojo;
  * Sends commands like start, stop to the ivy Engine
  */
 public class EngineControl {
-  public static interface Property {
+  public interface Property {
     String TEST_ENGINE_URL = "test.engine.url";
     String TEST_ENGINE_LOG = "test.engine.log";
   }
@@ -59,9 +59,8 @@ public class EngineControl {
     STOPPED, STARTING, RUNNING, STOPPING, UNREGISTERED, FAILED;
   }
 
-  private EngineMojoContext context;
-  private AtomicBoolean engineStarted = new AtomicBoolean(false);
-
+  private final EngineMojoContext context;
+  private final AtomicBoolean engineStarted = new AtomicBoolean(false);
 
   private enum Command {
     start, stop, status
@@ -84,10 +83,10 @@ public class EngineControl {
       streamHandler.start();
 
       process.onExit()
-        .thenAccept(p -> context.log.info("Engine process stopped."))
-        .exceptionally(ex -> {
-          throw new RuntimeException("Engine operation failed.", ex);
-      });
+          .thenAccept(p -> context.log.info("Engine process stopped."))
+          .exceptionally(ex -> {
+            throw new RuntimeException("Engine operation failed.", ex);
+          });
 
       waitForEngineStarted();
       return process;
@@ -179,8 +178,8 @@ public class EngineControl {
       i++;
       if (i / 2 > context.timeoutInSeconds) {
         throw new TimeoutException("Timeout while starting engine " + context.timeoutInSeconds + " [s].\n"
-                + "Check the engine log for details or increase the timeout property '"
-                + StartTestEngineMojo.IVY_ENGINE_START_TIMEOUT_SECONDS + "'");
+            + "Check the engine log for details or increase the timeout property '"
+            + StartTestEngineMojo.IVY_ENGINE_START_TIMEOUT_SECONDS + "'");
       }
     }
     context.log.info("Engine started after " + i / 2 + " [s]");
@@ -204,10 +203,10 @@ public class EngineControl {
 
   private EngineState parseState(String engineOut) {
     var state = engineOut.lines()
-            .map(line -> parse(line))
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
+        .map(this::parse)
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
     if (state == null) {
       context.log.error("Failed to evaluate engine state of engine in directory " + context.engineDirectory);
     }
@@ -236,7 +235,6 @@ public class EngineControl {
     }
     return watch.getDuration().toMillis();
   }
-
 
   private final class ProcessStreamHandler {
 

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineModuleHints.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineModuleHints.java
@@ -31,8 +31,8 @@ public class EngineModuleHints {
 
     try {
       return Files.readAllLines(jvmOptionsFile).stream()
-              .filter(line -> !line.isBlank())
-              .filter(line -> !line.matches("^\\s*#.*$"));
+          .filter(line -> !line.isBlank())
+          .filter(line -> !line.matches("^\\s*#.*$"));
     } catch (IOException ex) {
       log.warn("Couldn't read the jvm module options from '" + jvmOptionsFile + "' file.", ex);
       return Stream.empty();

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineMojoContext.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineMojoContext.java
@@ -38,7 +38,7 @@ public class EngineMojoContext {
   public final Integer timeoutInSeconds;
 
   public EngineMojoContext(Path engineDirectory, MavenProject project, Log log, Path engineLogFile,
-          EngineVmOptions vmOptions, Integer timeoutInSeconds) {
+      EngineVmOptions vmOptions, Integer timeoutInSeconds) {
     this.engineDirectory = engineDirectory;
     this.project = project;
     this.log = log;
@@ -63,10 +63,10 @@ public class EngineMojoContext {
       try {
         log.info("Creating a classpath jar for starting the engine");
         new ClasspathJar(classpathJar)
-                .createFileEntries(EngineClassLoaderFactory.getOsgiBootstrapClasspath(engineDirectory));
+            .createFileEntries(EngineClassLoaderFactory.getOsgiBootstrapClasspath(engineDirectory));
       } catch (Exception ex) {
         throw new RuntimeException(
-                "Could not create engine classpath jar: '" + classpathJar + "'", ex);
+            "Could not create engine classpath jar: '" + classpathJar + "'", ex);
       }
     }
     return classpathJar;

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineVersionEvaluator.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineVersionEvaluator.java
@@ -15,8 +15,8 @@ public class EngineVersionEvaluator {
 
   public static final String LIBRARY_ID = "ch.ivyteam.util";
 
-  private Log log;
-  private Path engineDir;
+  private final Log log;
+  private final Path engineDir;
 
   public EngineVersionEvaluator(Log log, Path engineDir) {
     this.log = log;

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/MavenProjectBuilderProxy.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/MavenProjectBuilderProxy.java
@@ -50,7 +50,7 @@ public class MavenProjectBuilderProxy {
   private final Log log;
 
   public MavenProjectBuilderProxy(EngineClassLoaderFactory classLoaderFactory, File workspace,
-          File baseDirToBuildIn, Log log, int timeoutEngineStartInSeconds) throws Exception {
+      File baseDirToBuildIn, Log log, int timeoutEngineStartInSeconds) throws Exception {
     this.baseDirToBuildIn = baseDirToBuildIn;
     this.log = log;
 
@@ -67,10 +67,10 @@ public class MavenProjectBuilderProxy {
   }
 
   private void logEngine()
-          throws ReflectionException, IntrospectionException, MalformedObjectNameException {
+      throws ReflectionException, IntrospectionException, MalformedObjectNameException {
     var cl = this.getClass().getClassLoader();
     var message = "MavenProjectBuilderProxy instance " + System.identityHashCode(this) +
-            " created with class loader " + cl + " (" + System.identityHashCode(cl) + ")";
+        " created with class loader " + cl + " (" + System.identityHashCode(cl) + ")";
     try {
       ManagementFactory.getPlatformMBeanServer().getMBeanInfo(new ObjectName("ivy Engine:type=Server"));
       log.warn(message + " ivy engine is already running!");
@@ -80,9 +80,9 @@ public class MavenProjectBuilderProxy {
   }
 
   private Class<?> getOsgiBundledDelegate(URLClassLoader ivyEngineClassLoader,
-          int timeoutEngineStartInSeconds) throws Exception {
+      int timeoutEngineStartInSeconds) throws Exception {
     Object bundleContext = new OsgiRuntime(baseDirToBuildIn.toPath(), log).startEclipseOsgiImpl(ivyEngineClassLoader,
-            timeoutEngineStartInSeconds);
+        timeoutEngineStartInSeconds);
     hackProvokeEagerStartOfJdt(bundleContext);
     Object buildBundle = findBundle(bundleContext, "ch.ivyteam.ivy.dataclasses.build");
     return loadClassInBundle(buildBundle, FQ_DELEGATE_CLASS_NAME);
@@ -90,12 +90,12 @@ public class MavenProjectBuilderProxy {
 
   private static Class<?> loadClassInBundle(Object bundle, String className) throws Exception {
     return (Class<?>) bundle.getClass().getDeclaredMethod("loadClass", String.class).invoke(bundle,
-            className);
+        className);
   }
 
   private static Object findBundle(Object bundleContext, String symbolicName) throws Exception {
     Object[] bundles = (Object[]) bundleContext.getClass().getDeclaredMethod("getBundles")
-            .invoke(bundleContext);
+        .invoke(bundleContext);
     for (Object bundleObj : bundles) {
       Object bundleSymbolicName = bundleObj.getClass().getMethod("getSymbolicName").invoke(bundleObj);
       if (symbolicName.equals(bundleSymbolicName)) {
@@ -107,8 +107,8 @@ public class MavenProjectBuilderProxy {
 
   private static String getEngineClasspath(List<File> jars) {
     return jars.stream()
-            .map(file -> file.getAbsolutePath())
-            .collect(Collectors.joining(File.pathSeparator));
+        .map(File::getAbsolutePath)
+        .collect(Collectors.joining(File.pathSeparator));
   }
 
   /**
@@ -133,26 +133,26 @@ public class MavenProjectBuilderProxy {
 
   @SuppressWarnings("unchecked")
   public Map<String, Object> compile(File projectDirToBuild, List<File> iarJars, Map<String, Object> options)
-          throws Exception {
+      throws Exception {
     Method compileMethod = getMethod("compile", File.class, List.class, String.class, Map.class);
     return (Map<String, Object>) executeInEngineDir(
-            () -> compileMethod.invoke(delegate, projectDirToBuild, iarJars, engineClasspath, options));
+        () -> compileMethod.invoke(delegate, projectDirToBuild, iarJars, engineClasspath, options));
   }
 
   @SuppressWarnings("unchecked")
   public Map<String, Object> validate(File projectDirToBuild, List<File> dependentProjects,
-          Map<String, Object> options) throws Exception {
+      Map<String, Object> options) throws Exception {
     Method validate = getMethod("validate", File.class, List.class, String.class, Map.class);
     return (Map<String, Object>) executeInEngineDir(
-            () -> validate.invoke(delegate, projectDirToBuild, dependentProjects, engineClasspath, options));
+        () -> validate.invoke(delegate, projectDirToBuild, dependentProjects, engineClasspath, options));
   }
 
   @SuppressWarnings("unchecked")
   public Map<String, Object> testCompile(File projectDirToBuild, List<File> iarJars,
-          Map<String, Object> options) throws Exception {
+      Map<String, Object> options) throws Exception {
     Method compileMethod = getMethod("testCompile", File.class, List.class, String.class, Map.class);
     return (Map<String, Object>) executeInEngineDir(
-            () -> compileMethod.invoke(delegate, projectDirToBuild, iarJars, engineClasspath, options));
+        () -> compileMethod.invoke(delegate, projectDirToBuild, iarJars, engineClasspath, options));
   }
 
   private Method getMethod(String name, Class<?>... parameterTypes) {
@@ -160,9 +160,9 @@ public class MavenProjectBuilderProxy {
       return delegateClass.getDeclaredMethod(name, parameterTypes);
     } catch (NoSuchMethodException ex) {
       throw new RuntimeException(
-              "Method " + name + "(" + parameterTypes + ") does not exist in engine '" + baseDirToBuildIn
-                      + "'. \n"
-                      + "You might need to configure another version to work with.");
+          "Method " + name + "(" + parameterTypes + ") does not exist in engine '" + baseDirToBuildIn
+              + "'. \n"
+              + "You might need to configure another version to work with.");
     }
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/Slf4jSimpleEngineProperties.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/Slf4jSimpleEngineProperties.java
@@ -30,17 +30,17 @@ import org.slf4j.simple.SimpleLogger;
 public class Slf4jSimpleEngineProperties {
   private static final String DEFAULT_LOG_LEVEL = SimpleLogger.DEFAULT_LOG_LEVEL_KEY;
   private static final List<String> INTERESTING_LOGGERS = Arrays.asList(
-          "ch.ivyteam.ivy.scripting.dataclass.internal.InMemoryEngineController", // engine
-                                                                                  // start/stop
-          "ch.ivyteam.ivy.project.build.MavenProjectBuilder", // maven engine
-                                                              // interface
-          "ch.ivyteam.ivy.scripting.dataclass.internal.ProjectDataClassManager", // dataclass
-                                                                                 // source
-                                                                                 // generation
-          "ch.ivyteam.ivy.java.internal.JavaBuilder", // jdt compiler
-          "ch.ivyteam.ivy.webservice.process.restricted.WebServiceProcessClassBuilder" // webservice
-                                                                                       // source
-                                                                                       // generation
+      "ch.ivyteam.ivy.scripting.dataclass.internal.InMemoryEngineController", // engine
+                                                                              // start/stop
+      "ch.ivyteam.ivy.project.build.MavenProjectBuilder", // maven engine
+                                                          // interface
+      "ch.ivyteam.ivy.scripting.dataclass.internal.ProjectDataClassManager", // dataclass
+                                                                             // source
+                                                                             // generation
+      "ch.ivyteam.ivy.java.internal.JavaBuilder", // jdt compiler
+      "ch.ivyteam.ivy.webservice.process.restricted.WebServiceProcessClassBuilder" // webservice
+                                                                                   // source
+                                                                                   // generation
   );
   private static final String IVY_PREFIX = "ch.ivyteam.ivy";
 
@@ -93,7 +93,7 @@ public class Slf4jSimpleEngineProperties {
   /**
    * Valid levels as documented in {@link org.slf4j.simple.SimpleLogger}
    */
-  static interface Level {
+  interface Level {
     String TRACE = "trace";
     String DEBUG = "debug";
     String INFO = "info";

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/DeploymentOptionsFileFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/DeploymentOptionsFileFactory.java
@@ -24,7 +24,7 @@ public class DeploymentOptionsFileFactory {
   }
 
   public Path createFromTemplate(Path optionsFile, MavenProject project, MavenSession session,
-          MavenFileFilter fileFilter) throws MojoExecutionException {
+      MavenFileFilter fileFilter) throws MojoExecutionException {
     if (!isOptionsFile(optionsFile.toFile())) {
       return null;
     }
@@ -33,7 +33,7 @@ public class DeploymentOptionsFileFactory {
     var targetFile = getTargetFile(ext);
     try {
       fileFilter.copyFile(optionsFile.toFile(), targetFile.toFile(), true, project, Collections.emptyList(), false,
-              StandardCharsets.UTF_8.name(), session);
+          StandardCharsets.UTF_8.name(), session);
     } catch (MavenFilteringException ex) {
       throw new MojoExecutionException("Failed to resolve templates in options file", ex);
     }
@@ -42,9 +42,9 @@ public class DeploymentOptionsFileFactory {
 
   private static boolean isOptionsFile(File optionsFile) {
     return optionsFile != null &&
-            optionsFile.exists() &&
-            optionsFile.isFile() &&
-            optionsFile.canRead();
+        optionsFile.exists() &&
+        optionsFile.isFile() &&
+        optionsFile.canRead();
   }
 
   public Path createFromConfiguration(String options) throws MojoExecutionException {

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/YamlOptionsFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/YamlOptionsFactory.java
@@ -38,7 +38,7 @@ public class YamlOptionsFactory {
 
     gen.close();
     String yaml = writer.toString();
-    if (yaml.equals("{}\n")) {
+    if ("{}\n".equals(yaml)) {
       return null;
     }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/EngineLogLineHandler.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/EngineLogLineHandler.java
@@ -23,7 +23,7 @@ import org.apache.maven.plugin.logging.Log;
 
 /**
  * Logs only log lines with a well known severity into maven log.
- * 
+ *
  * <p>
  * {@link Level#INFO} is logged as debug, as it contains information to trace
  * the detailed deployment steps which are too detailed for a normal deployment
@@ -47,21 +47,21 @@ class EngineLogLineHandler implements FileLogForwarder.LogLineHandler {
       String message = matcher.group(2);
       message = " ENGINE:" + message;
 
-      if (level.equalsIgnoreCase(Level.INFO)) { // infos are too detailed, but
+      if (Level.INFO.equalsIgnoreCase(level)) { // infos are too detailed, but
                                                 // users can trace in debug -X
                                                 // mode.
         log.debug(message);
       }
-      if (level.equalsIgnoreCase(Level.WARNING)) {
+      if (Level.WARNING.equalsIgnoreCase(level)) {
         log.warn(message);
       }
-      if (level.equalsIgnoreCase(Level.ERROR)) {
+      if (Level.ERROR.equalsIgnoreCase(level)) {
         log.error(message);
       }
     }
   }
 
-  static interface Level {
+  interface Level {
     String INFO = "info";
     String WARNING = "warning";
     String ERROR = "error";

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/FileDeployer.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/FileDeployer.java
@@ -36,7 +36,6 @@ public class FileDeployer implements IvyDeployer {
   private Log log;
   private DeploymentFiles deploymentFiles;
 
-
   public FileDeployer(Path deployDir, Path deploymentOptionsFile, Integer deployTimeoutInSeconds, Path deployFile, Path targetDeployableFile) {
     this.deployDir = deployDir;
     this.deploymentOptionsFile = deploymentOptionsFile;
@@ -118,7 +117,7 @@ public class FileDeployer implements IvyDeployer {
   }
 
   private static void wait(Supplier<Boolean> condition, long duration, TimeUnit unit)
-          throws TimeoutException {
+      throws TimeoutException {
     long waitMs = unit.toMillis(duration);
     long startMs = System.currentTimeMillis();
     long maxMs = waitMs + startMs;
@@ -128,8 +127,7 @@ public class FileDeployer implements IvyDeployer {
           throw new TimeoutException("Operation reached timeout of " + duration + " " + unit);
         }
         Thread.sleep(100);
-      } catch (InterruptedException ex) {
-      }
+      } catch (InterruptedException ex) {}
     }
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/FileLogForwarder.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/dir/FileLogForwarder.java
@@ -39,7 +39,7 @@ class FileLogForwarder {
   private final Log mavenLog;
 
   private FileAlterationMonitor monitor;
-  private LogLineHandler logLineHandler;
+  private final LogLineHandler logLineHandler;
 
   /**
    * @param engineLog the log file to watch for new lines
@@ -100,7 +100,7 @@ class FileLogForwarder {
     }
   }
 
-  static interface LogLineHandler {
+  interface LogLineHandler {
     void handleLine(String newLogLine);
   }
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/http/HttpDeployer.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/http/HttpDeployer.java
@@ -33,15 +33,15 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 
 public class HttpDeployer {
   private static final String DEPLOY_URI = "/system/api/apps/";
-  private String serverUrl;
-  private String targetApplication;
-  private Path deployFile;
-  private Path deploymentOptions;
-  private Server server;
-  private SecDispatcher secDispatcher;
+  private final String serverUrl;
+  private final String targetApplication;
+  private final Path deployFile;
+  private final Path deploymentOptions;
+  private final Server server;
+  private final SecDispatcher secDispatcher;
 
   public HttpDeployer(SecDispatcher secDispatcher, Server server, String serverUrl, String targetApplication,
-          Path deployFile, Path deploymentOptions) {
+      Path deployFile, Path deploymentOptions) {
     this.secDispatcher = secDispatcher;
     this.server = server;
     this.serverUrl = serverUrl;
@@ -61,7 +61,7 @@ public class HttpDeployer {
   }
 
   private void executeRequest(Log log, CloseableHttpClient client)
-          throws IOException, URISyntaxException, MojoExecutionException {
+      throws IOException, URISyntaxException, MojoExecutionException {
     String url = serverUrl + DEPLOY_URI + targetApplication;
     HttpPost httpPost = new HttpPost(url);
     httpPost.addHeader("X-Requested-By", "maven-build-plugin");
@@ -114,7 +114,7 @@ public class HttpDeployer {
     HttpHost httpHost = URIUtils.extractHost(new URI(url));
     CredentialsProvider credsProvider = new BasicCredentialsProvider();
     credsProvider.setCredentials(AuthScope.ANY,
-            new UsernamePasswordCredentials(username, password));
+        new UsernamePasswordCredentials(username, password));
     AuthCache authCache = new BasicAuthCache();
     authCache.put(httpHost, new BasicScheme());
     HttpClientContext context = HttpClientContext.create();

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/download/MavenEngineDownloader.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/download/MavenEngineDownloader.java
@@ -21,8 +21,8 @@ public class MavenEngineDownloader implements EngineDownloader {
   private final DefaultArtifact engineArtifact;
 
   public MavenEngineDownloader(Log log, String ivyVersion, String osArchitecture,
-          List<RemoteRepository> pluginRepositories, RepositorySystem repositorySystem,
-          RepositorySystemSession repositorySession) {
+      List<RemoteRepository> pluginRepositories, RepositorySystem repositorySystem,
+      RepositorySystemSession repositorySession) {
     this.log = log;
     this.engineArtifact = toEngineArtifact(ivyVersion, osArchitecture);
     this.repositorySystem = repositorySystem;

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/download/URLEngineDownloader.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/download/URLEngineDownloader.java
@@ -35,8 +35,8 @@ public class URLEngineDownloader implements EngineDownloader {
   public ProxyInfoProvider proxies;
 
   public URLEngineDownloader(URL engineDownloadUrl, URL engineListPageUrl, String osArchitecture,
-          String ivyVersion, VersionRange ivyVersionRange, Log log, Path downloadDirectory,
-          ProxyInfoProvider proxies) {
+      String ivyVersion, VersionRange ivyVersionRange, Log log, Path downloadDirectory,
+      ProxyInfoProvider proxies) {
     this.engineDownloadUrl = engineDownloadUrl;
     this.engineListPageUrl = engineListPageUrl;
     this.osArchitecture = osArchitecture;
@@ -81,7 +81,7 @@ public class URLEngineDownloader implements EngineDownloader {
       return downloadZip;
     } catch (Exception ex) {
       throw new MojoExecutionException("Failed to download engine from '" + engineUrl + "' to '"
-              + downloadDirectory + "'", ex);
+          + downloadDirectory + "'", ex);
     }
   }
 
@@ -128,7 +128,7 @@ public class URLEngineDownloader implements EngineDownloader {
   }
 
   public URL findEngineDownloadUrl(InputStream htmlStream)
-          throws MojoExecutionException, MalformedURLException, URISyntaxException {
+      throws MojoExecutionException, MalformedURLException, URISyntaxException {
     String engineFileNameRegex = "AxonIvyEngine[^.]+?\\.[^.]+?\\.+[^_]*?_" + osArchitecture + "\\.zip";
     Pattern enginePattern = Pattern.compile("href=[\"|'][^\"']*?" + engineFileNameRegex + "[\"|']");
     try (Scanner scanner = new Scanner(htmlStream)) {
@@ -137,12 +137,12 @@ public class URLEngineDownloader implements EngineDownloader {
         String engineLinkMatch = scanner.findWithinHorizon(enginePattern, 0);
         if (engineLinkMatch == null) {
           throw new MojoExecutionException("Could not find a link to engine for version '" + ivyVersion
-                  + "' on site '" + engineListPageUrl + "'");
+              + "' on site '" + engineListPageUrl + "'");
         }
         String versionString = StringUtils.substringBetween(engineLinkMatch, "AxonIvyEngine",
-                "_" + osArchitecture);
+            "_" + osArchitecture);
         ArtifactVersion version = new DefaultArtifactVersion(
-                EngineVersionEvaluator.toReleaseVersion(versionString));
+            EngineVersionEvaluator.toReleaseVersion(versionString));
         if (ivyVersionRange.containsVersion(version)) {
           engineLink = StringUtils.replace(engineLinkMatch, "\"", "'");
           engineLink = StringUtils.substringBetween(engineLink, "href='", "'");

--- a/src/main/java/ch/ivyteam/ivy/maven/test/AbstractIntegrationTestMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/test/AbstractIntegrationTestMojo.java
@@ -44,7 +44,7 @@ public abstract class AbstractIntegrationTestMojo extends AbstractEngineMojo {
 
   protected final boolean engineToTarget() throws MojoExecutionException {
     return isLocation(TestEngineLocation.COPY_FROM_TEMPLATE) ||
-            isLocation(TestEngineLocation.COPY_FROM_CACHE) && isCachedEngine();
+        isLocation(TestEngineLocation.COPY_FROM_CACHE) && isCachedEngine();
   }
 
   private boolean isLocation(String location) {
@@ -63,7 +63,7 @@ public abstract class AbstractIntegrationTestMojo extends AbstractEngineMojo {
     return Path.of(project.getBuild().getDirectory()).resolve("ivyEngine");
   }
 
-  static interface TestEngineLocation {
+  interface TestEngineLocation {
     String COPY_FROM_CACHE = "COPY_FROM_CACHE";
     String COPY_FROM_TEMPLATE = "COPY_FROM_TEMPLATE";
     String MODIFY_EXISTING = "MODIFY_EXISTING";

--- a/src/main/java/ch/ivyteam/ivy/maven/test/SetupIntegrationTestPropertiesMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/test/SetupIntegrationTestPropertiesMojo.java
@@ -55,17 +55,17 @@ public class SetupIntegrationTestPropertiesMojo extends AbstractEngineMojo {
   public void execute() throws MojoExecutionException, MojoFailureException {
     var props = new MavenProperties(project, getLog());
     String jmvArgs = asJvmArgs(props,
-            EngineControl.Property.TEST_ENGINE_URL,
-            EngineControl.Property.TEST_ENGINE_LOG,
-            DeployToTestEngineMojo.Property.TEST_ENGINE_APP);
+        EngineControl.Property.TEST_ENGINE_URL,
+        EngineControl.Property.TEST_ENGINE_LOG,
+        DeployToTestEngineMojo.Property.TEST_ENGINE_APP);
     jmvArgs += new EngineModuleHints(identifyAndGetEngineDirectory(), getLog()).asString();
     props.append(FAILSAFE_ARGLINE_PROPERTY, jmvArgs);
   }
 
   private static String asJvmArgs(MavenProperties store, String... keys) {
     return Arrays.stream(keys)
-            .map(key -> "-D" + key + "=" + store.get(key))
-            .collect(Collectors.joining(" "));
+        .map(key -> "-D" + key + "=" + store.get(key))
+        .collect(Collectors.joining(" "));
   }
 
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/test/SetupIvyTestPropertiesMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/test/SetupIvyTestPropertiesMojo.java
@@ -53,7 +53,7 @@ import ch.ivyteam.ivy.maven.util.SharedFile;
 public class SetupIvyTestPropertiesMojo extends AbstractEngineMojo {
   public static final String GOAL = "ivy-test-properties";
 
-  public static interface Property {
+  public interface Property {
     String IVY_ENGINE_CLASSPATH = "ivy.engine.classpath";
     String IVY_PROJECT_IAR_CLASSPATH = "ivy.project.iar.classpath";
     String IVY_TEST_VM_RUNTIME = "ivy.test.vm.runtime";
@@ -119,8 +119,8 @@ public class SetupIvyTestPropertiesMojo extends AbstractEngineMojo {
     deps.add(project.getBasedir().toPath());
     deps.addAll(MavenRuntime.getDependencies(project, session, "iar"));
     return deps.stream()
-            .map(file -> file.toUri())
-            .collect(Collectors.toList());
+        .map(Path::toUri)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -128,12 +128,12 @@ public class SetupIvyTestPropertiesMojo extends AbstractEngineMojo {
    */
   private void configureMavenTestProperties(MavenProperties properties) throws MojoExecutionException {
     List<String> IVY_PROPS = List.of(
-            Property.IVY_TEST_VM_RUNTIME,
-            Property.IVY_ENGINE_CLASSPATH,
-            Property.IVY_PROJECT_IAR_CLASSPATH);
+        Property.IVY_TEST_VM_RUNTIME,
+        Property.IVY_ENGINE_CLASSPATH,
+        Property.IVY_PROJECT_IAR_CLASSPATH);
     String surefireClasspath = IVY_PROPS.stream()
-            .map(property -> "${" + property + "}")
-            .collect(Collectors.joining(","));
+        .map(property -> "${" + property + "}")
+        .collect(Collectors.joining(","));
     properties.setMavenProperty(Property.MAVEN_TEST_ADDITIONAL_CLASSPATH, surefireClasspath);
     var jvmOptions = new EngineModuleHints(identifyAndGetEngineDirectory(), getLog());
     properties.append(Property.MAVEN_TEST_ARGLINE, jvmOptions.asString());

--- a/src/main/java/ch/ivyteam/ivy/maven/test/StartTestEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/test/StartTestEngineMojo.java
@@ -135,13 +135,13 @@ public class StartTestEngineMojo extends AbstractIntegrationTestMojo {
     var targetEngine = getTargetDir(project);
     if (Files.exists(targetEngine)) {
       getLog().warn("Skipping copy of engine to " + targetEngine
-              + " it already exists. Use \"mvn clean\" to ensure a clean engine each cycle.");
+          + " it already exists. Use \"mvn clean\" to ensure a clean engine each cycle.");
       return targetEngine;
     }
 
     try {
       getLog().info("Parameter <testEngine> is set to " + testEngine +
-              ", copying engine from: " + cachedEngineDir + " to " + targetEngine);
+          ", copying engine from: " + cachedEngineDir + " to " + targetEngine);
 
       copyEngine(cachedEngineDir, targetEngine);
       return targetEngine;

--- a/src/main/java/ch/ivyteam/ivy/maven/test/bpm/IvyTestRuntime.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/test/bpm/IvyTestRuntime.java
@@ -14,7 +14,7 @@ public class IvyTestRuntime {
 
   public static final String RUNTIME_PROPS_RESOURCE = "ivyTestRuntime.properties";
 
-  public static interface Key {
+  public interface Key {
     String PRODUCT_DIR = "product.dir";
     String PROJECT_LOCATIONS = "project.locations";
   }
@@ -27,10 +27,10 @@ public class IvyTestRuntime {
 
   public void setProjectLocations(List<URI> locations) {
     var joinedUris = locations
-            .stream()
-            .map(URI::toASCIIString)
-            .map(uri -> "<" + uri + ">") // RFC 3986 Appendix C
-            .collect(Collectors.joining(", "));
+        .stream()
+        .map(URI::toASCIIString)
+        .map(uri -> "<" + uri + ">") // RFC 3986 Appendix C
+        .collect(Collectors.joining(", "));
     props.setProperty(Key.PROJECT_LOCATIONS, joinedUris);
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/util/ClasspathJar.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/util/ClasspathJar.java
@@ -70,7 +70,7 @@ public class ClasspathJar {
   }
 
   private void writeManifest(String name, ZipOutputStream jarStream, List<String> classpathEntries)
-          throws IOException {
+      throws IOException {
     Manifest manifest = new Manifest();
     manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
     manifest.getMainAttributes().putValue("Name", name);
@@ -86,8 +86,8 @@ public class ClasspathJar {
 
   private static List<String> getClassPathUris(Collection<File> classpathEntries) {
     return classpathEntries.stream()
-            .map(file -> file.toURI().toASCIIString())
-            .collect(Collectors.toList());
+        .map(file -> file.toURI().toASCIIString())
+        .collect(Collectors.toList());
   }
 
   public List<File> getFiles() {

--- a/src/main/java/ch/ivyteam/ivy/maven/util/FileSetConverter.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/util/FileSetConverter.java
@@ -33,7 +33,7 @@ public class FileSetConverter {
   }
 
   public List<org.codehaus.plexus.archiver.FileSet> toPlexusFileSets(
-          org.apache.maven.model.FileSet[] mavenFileSets) {
+      org.apache.maven.model.FileSet[] mavenFileSets) {
     if (mavenFileSets == null) {
       return Collections.emptyList();
     }

--- a/src/main/java/ch/ivyteam/ivy/maven/util/MavenDependencies.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/util/MavenDependencies.java
@@ -33,28 +33,28 @@ public class MavenDependencies {
 
   public List<Path> localTransient() {
     return stream(project.getArtifacts())
-      .filter(this::isLocalDep)
-      .filter(this::include)
-      .map(Artifact::getFile)
-      .map(File::toPath)
-      .filter(Objects::nonNull)
-      .collect(Collectors.toList());
+        .filter(this::isLocalDep)
+        .filter(this::include)
+        .map(Artifact::getFile)
+        .map(File::toPath)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
   }
 
   private boolean isLocalDep(Artifact artifact) {
     return artifact.getDependencyTrail().stream()
-      .filter(dep -> dep.contains(":iar")) // iar or iar-integration-test
-      .filter(dep -> !dep.startsWith(project.getGroupId() + ":" + project.getArtifactId() + ":"))
-      .findAny()
-      .isEmpty();
+        .filter(dep -> dep.contains(":iar")) // iar or iar-integration-test
+        .filter(dep -> !dep.startsWith(project.getGroupId() + ":" + project.getArtifactId() + ":"))
+        .findAny()
+        .isEmpty();
   }
 
   public List<Path> all() {
     return stream(project.getArtifacts())
-      .filter(this::include)
-      .map(this::toFile)
-      .map(File::toPath)
-      .collect(Collectors.toList());
+        .filter(this::include)
+        .map(this::toFile)
+        .map(File::toPath)
+        .collect(Collectors.toList());
   }
 
   private static Stream<Artifact> stream(Set<Artifact> deps) {
@@ -66,8 +66,8 @@ public class MavenDependencies {
 
   private File toFile(Artifact artifact) {
     return findReactorProject(artifact)
-      .map(MavenProject::getBasedir)
-      .orElse(artifact.getFile());
+        .map(MavenProject::getBasedir)
+        .orElse(artifact.getFile());
   }
 
   private boolean include(Artifact artifact) {
@@ -85,8 +85,8 @@ public class MavenDependencies {
       return Optional.empty();
     }
     return session.getAllProjects().stream()
-            .filter(p -> p.getArtifact().equals(artifact))
-            .findAny();
+        .filter(p -> p.getArtifact().equals(artifact))
+        .findAny();
   }
 
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/util/PathUtils.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/util/PathUtils.java
@@ -11,15 +11,15 @@ import org.apache.commons.lang3.StringUtils;
 
 public interface PathUtils {
 
-  public static String toExtension(Path path) {
+  static String toExtension(Path path) {
     return toExtension(path.getFileName().toString());
   }
 
-  public static String toExtension(String path) {
+  static String toExtension(String path) {
     return StringUtils.substringAfterLast(path, ".");
   }
 
-  public static void delete(Path path) {
+  static void delete(Path path) {
     if (path == null) {
       return;
     }
@@ -29,14 +29,14 @@ public interface PathUtils {
 
     try (var stream = Files.walk(path)) {
       stream.sorted(Comparator.reverseOrder())
-              .map(Path::toFile)
-              .forEach(File::delete);
+          .map(Path::toFile)
+          .forEach(File::delete);
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);
     }
   }
 
-  public static void clean(Path path) {
+  static void clean(Path path) {
     delete(path);
     try {
       Files.createDirectories(path);

--- a/src/main/java/ch/ivyteam/ivy/maven/validate/ValidateMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/validate/ValidateMojo.java
@@ -69,8 +69,9 @@ public class ValidateMojo extends AbstractMojo {
   private String versionProjects(Map<String, Set<MavenProject>> versionToProjectsMap, String version) {
     return version + " -> [" +
         versionToProjectsMap.get(version).stream()
-            .map(p -> p.getArtifactId())
-            .collect(Collectors.joining(", ")) +
+            .map(MavenProject::getArtifactId)
+            .collect(Collectors.joining(", "))
+        +
         "]";
   }
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/BaseEngineProjectMojoTest.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/BaseEngineProjectMojoTest.java
@@ -51,12 +51,11 @@ public class BaseEngineProjectMojoTest {
   private static String getNextMajor(String version) {
     DefaultArtifactVersion parsed = new DefaultArtifactVersion(version);
     int majorVersion = parsed.getMajorVersion();
-    String nextMajor = new StringBuilder()
-            .append(majorVersion + 1).append('.')
-            .append(parsed.getMinorVersion()).append('.')
-            .append(parsed.getIncrementalVersion())
-            .toString();
-    return nextMajor;
+    return new StringBuilder()
+        .append(majorVersion + 1).append('.')
+        .append(parsed.getMinorVersion()).append('.')
+        .append(parsed.getIncrementalVersion())
+        .toString();
   }
 
   private static String getLocalRepoPath() {
@@ -66,8 +65,8 @@ public class BaseEngineProjectMojoTest {
     }
 
     StringBuilder defaultHomePath = new StringBuilder(SystemUtils.USER_HOME)
-            .append(File.separatorChar).append(".m2")
-            .append(File.separatorChar).append("repository");
+        .append(File.separatorChar).append(".m2")
+        .append(File.separatorChar).append("repository");
     return defaultHomePath.toString();
   }
 
@@ -76,8 +75,8 @@ public class BaseEngineProjectMojoTest {
   }
 
   @Rule
-  public ProjectMojoRule<InstallEngineMojo> installUpToDateEngineRule = new ProjectMojoRule<InstallEngineMojo>(
-          Path.of("src/test/resources/base"), InstallEngineMojo.GOAL) {
+  public ProjectMojoRule<InstallEngineMojo> installUpToDateEngineRule = new ProjectMojoRule<>(
+      Path.of("src/test/resources/base"), InstallEngineMojo.GOAL){
 
     private static final String TIMESTAMP_FILE_NAME = "downloadtimestamp";
 
@@ -122,8 +121,7 @@ public class BaseEngineProjectMojoTest {
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.DAY_OF_YEAR, -1);
         long yesterday = cal.getTimeInMillis();
-        boolean cachedEngineIsOlderThan24h = yesterday > createTimeMillis;
-        return cachedEngineIsOlderThan24h;
+        return yesterday > createTimeMillis;
       } catch (IOException ex) { // corrupt state - trigger re-download
         return true;
       }
@@ -172,7 +170,7 @@ public class BaseEngineProjectMojoTest {
     private void provideClasspathJar() throws IOException {
       var cpJar = new SharedFile(project).getEngineOSGiBootClasspathJar();
       new ClasspathJar(cpJar).createFileEntries(EngineClassLoaderFactory
-              .getOsgiBootstrapClasspath(installUpToDateEngineRule.getMojo().getRawEngineDirectory()));
+          .getOsgiBootstrapClasspath(installUpToDateEngineRule.getMojo().getRawEngineDirectory()));
     }
 
     @Override

--- a/src/test/java/ch/ivyteam/ivy/maven/ProjectMojoRule.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/ProjectMojoRule.java
@@ -40,8 +40,8 @@ public class ProjectMojoRule<T extends Mojo> extends MojoRule {
 
   protected Path projectDir;
   private T mojo;
-  private String mojoName;
-  private Path templateProjectDir;
+  private final String mojoName;
+  private final Path templateProjectDir;
   public MavenProject project;
 
   public ProjectMojoRule(Path srcDir, String mojoName) {

--- a/src/test/java/ch/ivyteam/ivy/maven/TestIarPackagingMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestIarPackagingMojo.java
@@ -45,8 +45,8 @@ import ch.ivyteam.ivy.maven.util.PathUtils;
 public class TestIarPackagingMojo {
 
   @Rule
-  public ProjectMojoRule<IarPackagingMojo> rule = new ProjectMojoRule<IarPackagingMojo>(
-          Path.of("src/test/resources/base"), IarPackagingMojo.GOAL) {
+  public ProjectMojoRule<IarPackagingMojo> rule = new ProjectMojoRule<>(
+      Path.of("src/test/resources/base"), IarPackagingMojo.GOAL){
 
     @Override
     protected void before() throws Throwable {
@@ -82,28 +82,28 @@ public class TestIarPackagingMojo {
     var iarFile = iarFiles.getFirst();
     assertThat(iarFile).hasFileName("base-1.0.0.iar");
     assertThat(mojo.project.getArtifact().getFile())
-            .as("Created IAR must be registered as artifact for later repository installation.")
-            .isEqualTo(iarFile.toFile());
+        .as("Created IAR must be registered as artifact for later repository installation.")
+        .isEqualTo(iarFile.toFile());
 
     try (ZipFile archive = new ZipFile(iarFile.toFile())) {
       assertThat(archive.getEntry(".classpath")).as(".classpath must be packed for internal binary retrieval")
-              .isNotNull();
+          .isNotNull();
       assertThat(archive.getEntry("src_hd")).as("Empty directories should be included (by default) "
-              + "so that the IAR can be re-imported into the designer").isNotNull();
+          + "so that the IAR can be re-imported into the designer").isNotNull();
       assertThat(archive.getEntry("target/sampleOutput.txt"))
-              .as("'target/sampleOutput.txt' should not be packed").isNull();
+          .as("'target/sampleOutput.txt' should not be packed").isNull();
       assertThat(archive.getEntry("target")).as("'target' must be packed because there are target/classes")
-              .isNotNull();
+          .isNotNull();
       assertThat(archive.getEntry(".svn/svn.txt")).as("'.svn' folder should not be packed").isNull();
       assertThat(archive.getEntry(".svn")).as("'target'.svn should not be packed").isNull();
       assertThat(archive.getEntry("classes/gugus.txt")).as("classes content should be included by default")
-              .isNotNull();
+          .isNotNull();
       assertThat(archive.getEntry("target/classes/gugus.txt"))
-              .as("target/classes content should be included by default").isNotNull();
+          .as("target/classes content should be included by default").isNotNull();
       assertThat(archive.getEntry("target/classesAnother/gugus.txt"))
-              .as("target/classesAnother should not be packed by default").isNull();
+          .as("target/classesAnother should not be packed by default").isNull();
       assertThat(archive.getEntry("target/anythingelse/gugus.txt"))
-              .as("target/anythingelse should not be packed by default").isNull();
+          .as("target/anythingelse should not be packed by default").isNull();
     }
   }
 
@@ -143,7 +143,7 @@ public class TestIarPackagingMojo {
     mojo.execute();
     try (ZipFile archive = new ZipFile(mojo.project.getArtifact().getFile())) {
       assertThat(archive.getEntry(relativeCustomIncludePath)).as("Custom inclusions must be included")
-              .isNotNull();
+          .isNotNull();
     }
   }
 
@@ -164,16 +164,16 @@ public class TestIarPackagingMojo {
       try (InputStream is = archive.getInputStream(archive.getEntry("pom.xml"))) {
         String pomInArchive = new String(is.readAllBytes(), StandardCharsets.UTF_8);
         assertThat(pomInArchive)
-                .as("customer should be able to overwrite pre-defined resource with their own includes.")
-                .contains("flattened");
+            .as("customer should be able to overwrite pre-defined resource with their own includes.")
+            .contains("flattened");
       }
 
       List<? extends ZipEntry> pomEntries = Collections.list(archive.entries()).stream()
-              .filter(entry -> entry.getName().equals("pom.xml"))
-              .collect(Collectors.toList());
+          .filter(entry -> "pom.xml".equals(entry.getName()))
+          .collect(Collectors.toList());
       assertThat(pomEntries)
-              .as("if same path is specified twice, the users entry should win and no duplicates must exist.")
-              .hasSize(1);
+          .as("if same path is specified twice, the users entry should win and no duplicates must exist.")
+          .hasSize(1);
     }
   }
 
@@ -185,7 +185,7 @@ public class TestIarPackagingMojo {
 
     try (ZipFile archive = new ZipFile(mojo.project.getArtifact().getFile())) {
       assertThat(archive.getEntry("src_hd")).as("Empty directory should be excluded by mojo configuration")
-              .isNull();
+          .isNull();
     }
   }
 
@@ -203,7 +203,7 @@ public class TestIarPackagingMojo {
     var iarFile = iarFiles.getFirst();
     try (ZipFile archive = new ZipFile(iarFile.toFile())) {
       assertThat(archive.getEntry("target"))
-              .as("'target' will not be packed when there are no target/classes").isNull();
+          .as("'target' will not be packed when there are no target/classes").isNull();
     }
   }
 
@@ -213,7 +213,7 @@ public class TestIarPackagingMojo {
 
     var target = mojo.project.getBasedir().toPath().resolve("target");
     var viewGenerated = target.resolve("src_hd")
-      .resolve("com").resolve("acme").resolve("FormDialog").resolve("FormDialog.xhtml");
+        .resolve("com").resolve("acme").resolve("FormDialog").resolve("FormDialog.xhtml");
     Files.createDirectories(viewGenerated.getParent());
     Files.writeString(viewGenerated, "<html/>", StandardOpenOption.CREATE_NEW);
 
@@ -226,7 +226,7 @@ public class TestIarPackagingMojo {
     var iarFile = iarFiles.getFirst();
     try (ZipFile archive = new ZipFile(iarFile.toFile())) {
       assertThat(archive.getEntry("target/src_hd/com/acme/FormDialog/FormDialog.xhtml"))
-              .as("generated jsf.dialog views are included").isNotNull();
+          .as("generated jsf.dialog views are included").isNotNull();
     }
   }
 

--- a/src/test/java/ch/ivyteam/ivy/maven/TestInstallEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestInstallEngineMojo.java
@@ -51,8 +51,8 @@ public class TestInstallEngineMojo {
   private InstallEngineMojo mojo;
 
   @Rule
-  public ProjectMojoRule<InstallEngineMojo> rule = new ProjectMojoRule<InstallEngineMojo>(
-          Path.of("src/test/resources/base"), InstallEngineMojo.GOAL) {
+  public ProjectMojoRule<InstallEngineMojo> rule = new ProjectMojoRule<>(
+      Path.of("src/test/resources/base"), InstallEngineMojo.GOAL){
     @Override
     protected void before() throws Throwable {
       super.before();
@@ -84,7 +84,7 @@ public class TestInstallEngineMojo {
     var listPageResponse = new MockHttpServerResponse();
     String defaultEngineName = "AxonIvyEngine" + DEFAULT_VERSION + ".46949_" + DEFAULT_ARCH;
     listPageResponse.setMockResponseContent(
-      "<a href=\"" + mockBaseUrl + "/" + defaultEngineName + ".zip\">the engine!</a>");
+        "<a href=\"" + mockBaseUrl + "/" + defaultEngineName + ".zip\">the engine!</a>");
     mockServer.setMockHttpServerResponses(listPageResponse, createFakeZipResponse(createFakeEngineZip(mojo.ivyVersion)));
 
     // test setup can not expand expression ${settings.localRepository}: so we
@@ -95,18 +95,18 @@ public class TestInstallEngineMojo {
     var defaultEngineDir = mojo.engineCacheDirectory.resolve(DEFAULT_VERSION);
     assertThat(defaultEngineDir).doesNotExist();
     assertThat(mojo.engineDownloadUrl)
-      .as("Default config should favour to download an engine from the 'list page url'.")
-      .isNull();
+        .as("Default config should favour to download an engine from the 'list page url'.")
+        .isNull();
     assertThat(mojo.autoInstallEngine).isTrue();
 
     mojo.execute();
 
     assertThat(defaultEngineDir)
-      .as("Engine must be automatically downloaded")
-      .exists()
-      .isDirectory()
-      .as("Engine directory should automatically be set to subdir of the local repository cache.")
-      .isEqualTo(mojo.getRawEngineDirectory());
+        .as("Engine must be automatically downloaded")
+        .exists()
+        .isDirectory()
+        .as("Engine directory should automatically be set to subdir of the local repository cache.")
+        .isEqualTo(mojo.getRawEngineDirectory());
   }
 
   private static MockHttpServerResponse createFakeZipResponse(Path zip) throws Exception {
@@ -180,8 +180,8 @@ public class TestInstallEngineMojo {
   public void testEngineDownload_ifNotExisting() throws Exception {
     mojo.engineDirectory = createTempDir("tmpEngine");
     assertThat(mojo.engineDirectory)
-      .isDirectory()
-      .isEmptyDirectory();
+        .isDirectory()
+        .isEmptyDirectory();
 
     mojo.autoInstallEngine = true;
     mockServer.setMockHttpServerResponses(createFakeZipResponse(createFakeEngineZip(mojo.ivyVersion)));
@@ -250,8 +250,8 @@ public class TestInstallEngineMojo {
     downloader.proxies = this::localTestProxy;
     var downloaded = downloader.downloadEngine();
     assertThat(downloaded)
-            .as("served file via proxy")
-            .exists();
+        .as("served file via proxy")
+        .exists();
   }
 
   private ProxyInfo localTestProxy(@SuppressWarnings("unused") String protocol) {
@@ -297,7 +297,7 @@ public class TestInstallEngineMojo {
     mojo.restrictVersionToMinimalCompatible = false;
     mojo.osArchitecture = "Windows_x86";
     assertThat(findLink("<a href=\"http://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>"))
-      .isEqualTo("http://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
+        .isEqualTo("http://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
   }
 
   @Test
@@ -306,7 +306,7 @@ public class TestInstallEngineMojo {
     mojo.restrictVersionToMinimalCompatible = false;
     mojo.osArchitecture = "Windows_x86";
     assertThat(findLink("<a href=\"https://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>"))
-       .isEqualTo("https://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
+        .isEqualTo("https://developer.axonivy.com/download/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
   }
 
   @Test
@@ -316,7 +316,7 @@ public class TestInstallEngineMojo {
     mojo.osArchitecture = "Windows_x86";
     mojo.engineListPageUrl = URI.create("http://localhost/").toURL();
     assertThat(findLink("<a href=\"7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>"))
-      .isEqualTo("http://localhost/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
+        .isEqualTo("http://localhost/7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip");
   }
 
   @Test
@@ -325,8 +325,8 @@ public class TestInstallEngineMojo {
     mojo.restrictVersionToMinimalCompatible = false;
     mojo.osArchitecture = "Windows_x64";
     assertThat(findLink(
-            "<a href=\"http://www.ivyteam.ch/downloads/XIVY/Saentis/7.0.0-S2/AxonIvyEngine7.0.0.47245.S2_Windows_x64.zip\">Axon Ivy Engine Windows x64</a>"))
-      .isEqualTo("http://www.ivyteam.ch/downloads/XIVY/Saentis/7.0.0-S2/AxonIvyEngine7.0.0.47245.S2_Windows_x64.zip");
+        "<a href=\"http://www.ivyteam.ch/downloads/XIVY/Saentis/7.0.0-S2/AxonIvyEngine7.0.0.47245.S2_Windows_x64.zip\">Axon Ivy Engine Windows x64</a>"))
+            .isEqualTo("http://www.ivyteam.ch/downloads/XIVY/Saentis/7.0.0-S2/AxonIvyEngine7.0.0.47245.S2_Windows_x64.zip");
   }
 
   @Test
@@ -338,7 +338,7 @@ public class TestInstallEngineMojo {
       failBecauseExceptionWasNotThrown(MojoExecutionException.class);
     } catch (MojoExecutionException ex) {
       assertThat(ex).hasMessageStartingWith(
-              "Could not find a link to engine for version '" + DEFAULT_VERSION + "'");
+          "Could not find a link to engine for version '" + DEFAULT_VERSION + "'");
     }
   }
 
@@ -348,11 +348,11 @@ public class TestInstallEngineMojo {
     mojo.osArchitecture = "Linux_x86";
     try {
       findLink("<a href=\"" + DEFAULT_VERSION + "/AxonIvyEngine"
-              + DEFAULT_VERSION + ".46949_Windows_x86.zip\">the latest engine</a>");
+          + DEFAULT_VERSION + ".46949_Windows_x86.zip\">the latest engine</a>");
       failBecauseExceptionWasNotThrown(MojoExecutionException.class);
     } catch (MojoExecutionException ex) {
       assertThat(ex).hasMessageStartingWith(
-              "Could not find a link to engine for version '" + DEFAULT_VERSION + "'");
+          "Could not find a link to engine for version '" + DEFAULT_VERSION + "'");
     }
   }
 
@@ -364,9 +364,9 @@ public class TestInstallEngineMojo {
     mojo.engineListPageUrl = URI.create("http://localhost/").toURL();
 
     assertThat(findLink(
-            "<a href=\"7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>" // windows
-                    + "<a href=\"7.0.0/AxonIvyEngine7.0.0.46949_Linux_x86.zip\">the latest engine</a>")) // linux
-      .isEqualTo("http://localhost/7.0.0/AxonIvyEngine7.0.0.46949_Linux_x86.zip");
+        "<a href=\"7.0.0/AxonIvyEngine7.0.0.46949_Windows_x86.zip\">the latest engine</a>" // windows
+            + "<a href=\"7.0.0/AxonIvyEngine7.0.0.46949_Linux_x86.zip\">the latest engine</a>")) // linux
+                .isEqualTo("http://localhost/7.0.0/AxonIvyEngine7.0.0.46949_Linux_x86.zip");
   }
 
   private String findLink(String html) throws MojoExecutionException, URISyntaxException, IOException {
@@ -384,10 +384,10 @@ public class TestInstallEngineMojo {
 
     String engineUrl = getUrlDownloader().findEngineDownloadUrl(mojo.engineListPageUrl.openStream()).toExternalForm();
     assertThat(engineUrl)
-      .as("The default engine list page url '" + mojo.engineListPageUrl.toExternalForm() + "' "
-              + "must provide an engine for the current default engine version '" + mojo.ivyVersion
-              + "'.")
-      .contains(mojo.ivyVersion);
+        .as("The default engine list page url '" + mojo.engineListPageUrl.toExternalForm() + "' "
+            + "must provide an engine for the current default engine version '" + mojo.ivyVersion
+            + "'.")
+        .contains(mojo.ivyVersion);
   }
 
   private URLEngineDownloader getUrlDownloader() throws MojoExecutionException {
@@ -408,14 +408,14 @@ public class TestInstallEngineMojo {
   @Test
   public void testZipFileEngineVersionParser() {
     assertThat(InstallEngineMojo.ivyEngineVersionOfZip("AxonIvyEngine6.1.1.51869_Linux_x64.zip"))
-      .isEqualTo("6.1.1");
+        .isEqualTo("6.1.1");
     assertThat(InstallEngineMojo.ivyEngineVersionOfZip("AxonIvyEngine6.2_Windows_x64.zip"))
-      .isEqualTo("6.2");
+        .isEqualTo("6.2");
     assertThat(InstallEngineMojo
-      .ivyEngineVersionOfZip("AxonIvyDesigner6.1.1-SNAPSHOT.51869-win32.win32.x86_64.zip"))
-      .isEqualTo("6.1.1");
+        .ivyEngineVersionOfZip("AxonIvyDesigner6.1.1-SNAPSHOT.51869-win32.win32.x86_64.zip"))
+            .isEqualTo("6.1.1");
     assertThat(InstallEngineMojo.ivyEngineVersionOfZip("AxonIvyEngine_Linux_x64.zip"))
-      .isEqualTo("AxonIvyEngine_Linux_x64.zip"); // do not return null!
+        .isEqualTo("AxonIvyEngine_Linux_x64.zip"); // do not return null!
   }
 
   private static String getFakeLibraryPath(final String version) {

--- a/src/test/java/ch/ivyteam/ivy/maven/TestLoggerIntegration.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestLoggerIntegration.java
@@ -40,7 +40,7 @@ public class TestLoggerIntegration extends BaseEngineProjectMojoTest {
     assertThat(slf4jJars).hasSize(3);
     assertThat(slf4jJars.get(0).getName()).startsWith("slf4j-api-");
     assertThat(outContent.toString())
-            .as("no warnings must be printed during slf4j library re-solving from local repo")
-            .isEmpty();
+        .as("no warnings must be printed during slf4j library re-solving from local repo")
+        .isEmpty();
   }
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/TestMavenDependencyCleanupMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestMavenDependencyCleanupMojo.java
@@ -26,8 +26,8 @@ import org.junit.Test;
 
 public class TestMavenDependencyCleanupMojo extends BaseEngineProjectMojoTest {
   @Rule
-  public ProjectMojoRule<MavenDependencyCleanupMojo> compile = new ProjectMojoRule<MavenDependencyCleanupMojo>(
-          Path.of("src/test/resources/base"), MavenDependencyCleanupMojo.GOAL);
+  public ProjectMojoRule<MavenDependencyCleanupMojo> compile = new ProjectMojoRule<>(
+      Path.of("src/test/resources/base"), MavenDependencyCleanupMojo.GOAL);
 
   @Test
   public void noMavenDepsDir() throws Exception {
@@ -42,7 +42,7 @@ public class TestMavenDependencyCleanupMojo extends BaseEngineProjectMojoTest {
   public void cleanupMavenDepsDir() throws Exception {
     var mojo = compile.getMojo();
     var mvnLibDir = Files
-            .createDirectories(mojo.project.getBasedir().toPath().resolve("lib").resolve("mvn-deps"));
+        .createDirectories(mojo.project.getBasedir().toPath().resolve("lib").resolve("mvn-deps"));
     var mvnDep = Files.copy(Path.of("src/test/resources/jjwt-0.9.1.jar"), mvnLibDir.resolve("jjwt-0.9.1.jar"));
     assertThat(mvnLibDir).exists();
     assertThat(mvnDep).exists();

--- a/src/test/java/ch/ivyteam/ivy/maven/TestMavenDependencyMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestMavenDependencyMojo.java
@@ -37,8 +37,8 @@ public class TestMavenDependencyMojo extends BaseEngineProjectMojoTest {
   private MavenDependencyMojo testMojo;
 
   @Rule
-  public CompileMojoRule<MavenDependencyMojo> deps = new CompileMojoRule<MavenDependencyMojo>(
-          MavenDependencyMojo.GOAL) {
+  public CompileMojoRule<MavenDependencyMojo> deps = new CompileMojoRule<>(
+      MavenDependencyMojo.GOAL){
     @Override
     protected void before() throws Throwable {
       super.before();
@@ -80,12 +80,12 @@ public class TestMavenDependencyMojo extends BaseEngineProjectMojoTest {
     Artifact artifact = new ArtifactStubFactory().createArtifact("io.jsonwebtoken", "jjwt", "0.9.1");
     artifact.setFile(Path.of("src/test/resources/jjwt-0.9.1.jar").toFile());
     artifact.setDependencyTrail(
-            List.of(mojo.project.getArtifact().toString(), "other.group:other.artifact:iar:1.0.0"));
+        List.of(mojo.project.getArtifact().toString(), "other.group:other.artifact:iar:1.0.0"));
     mojo.project.setArtifacts(Set.of(artifact));
     mojo.execute();
     assertThat(getMavenLibs(mvnLibDir))
-            .as("libs provided through a dependent 'iar' should not be packed.")
-            .isEmpty();
+        .as("libs provided through a dependent 'iar' should not be packed.")
+        .isEmpty();
   }
 
   private static List<String> getMavenLibs(Path mvnLibDir) throws IOException {
@@ -94,9 +94,9 @@ public class TestMavenDependencyMojo extends BaseEngineProjectMojoTest {
     }
     try (var walker = Files.walk(mvnLibDir, 1)) {
       return walker
-              .filter(p -> !p.equals(mvnLibDir))
-              .map(p -> p.getFileName().toString())
-              .collect(Collectors.toList());
+          .filter(p -> !p.equals(mvnLibDir))
+          .map(p -> p.getFileName().toString())
+          .collect(Collectors.toList());
     }
   }
 

--- a/src/test/java/ch/ivyteam/ivy/maven/TestShareEngineClasspathMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestShareEngineClasspathMojo.java
@@ -34,22 +34,22 @@ public class TestShareEngineClasspathMojo {
   public void engineClasspathIsSharedAsProperty() throws Exception {
     ShareEngineCoreClasspathMojo mojo = rule.getMojo();
     assertThat(getEngineClasspathProperty())
-            .as("used classpath has not been evaluated.")
-            .isNullOrEmpty();
+        .as("used classpath has not been evaluated.")
+        .isNullOrEmpty();
 
     mojo.execute();
     assertThat(getEngineClasspathProperty())
-            .as("used classpath must be shared as property so that other mojos can access it")
-            .contains("dummy-boot.jar");
+        .as("used classpath must be shared as property so that other mojos can access it")
+        .contains("dummy-boot.jar");
   }
 
   private String getEngineClasspathProperty() {
     return (String) rule.getMojo().project.getProperties()
-            .get(ShareEngineCoreClasspathMojo.IVY_ENGINE_CORE_CLASSPATH_PROPERTY);
+        .get(ShareEngineCoreClasspathMojo.IVY_ENGINE_CORE_CLASSPATH_PROPERTY);
   }
 
   @Rule
-  public ProjectMojoRule<ShareEngineCoreClasspathMojo> rule = new ProjectMojoRule<ShareEngineCoreClasspathMojo>(Path.of("src/test/resources/base"), ShareEngineCoreClasspathMojo.GOAL) {
+  public ProjectMojoRule<ShareEngineCoreClasspathMojo> rule = new ProjectMojoRule<ShareEngineCoreClasspathMojo>(Path.of("src/test/resources/base"), ShareEngineCoreClasspathMojo.GOAL){
 
     @Override
     protected void before() throws Throwable {

--- a/src/test/java/ch/ivyteam/ivy/maven/TestSlf4jWarningConfiguration.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestSlf4jWarningConfiguration.java
@@ -17,7 +17,7 @@ class TestSlf4jWarningConfiguration {
   void mavenLikeWarning() {
     Slf4jSimpleEngineProperties.install();
     assertThat(System.getProperty(SimpleLogger.WARN_LEVEL_STRING_KEY))
-            .as("SLF4J warning string is not maven-like [WARNING]")
-            .isEqualTo("WARNING");
+        .as("SLF4J warning string is not maven-like [WARNING]")
+        .isEqualTo("WARNING");
   }
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/compile/CompileMojoRule.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/compile/CompileMojoRule.java
@@ -51,13 +51,13 @@ public class CompileMojoRule<T extends AbstractEngineInstanceMojo> extends Engin
   private ArtifactRepository provideLocalRepository() throws IllegalAccessException {
     DefaultArtifactRepositoryFactory factory = new DefaultArtifactRepositoryFactory();
     setVariableValueToObject(factory, "factory",
-            new org.apache.maven.repository.legacy.repository.DefaultArtifactRepositoryFactory());
+        new org.apache.maven.repository.legacy.repository.DefaultArtifactRepositoryFactory());
 
     LegacySupport legacySupport = new DefaultLegacySupport();
     setVariableValueToObject(factory, "legacySupport", legacySupport);
 
     ArtifactRepository localRepository = factory.createArtifactRepository("local", "http://localhost",
-            new DefaultRepositoryLayout(), new ArtifactRepositoryPolicy(), new ArtifactRepositoryPolicy());
+        new DefaultRepositoryLayout(), new ArtifactRepositoryPolicy(), new ArtifactRepositoryPolicy());
 
     setVariableValueToObject(localRepository, "basedir", BaseEngineProjectMojoTest.LOCAL_REPOSITORY);
 

--- a/src/test/java/ch/ivyteam/ivy/maven/compile/TestCompileProjectMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/compile/TestCompileProjectMojo.java
@@ -34,8 +34,8 @@ public class TestCompileProjectMojo extends BaseEngineProjectMojoTest {
   private CompileTestProjectMojo testMojo;
 
   @Rule
-  public CompileMojoRule<CompileProjectMojo> compile = new CompileMojoRule<CompileProjectMojo>(
-          CompileProjectMojo.GOAL) {
+  public CompileMojoRule<CompileProjectMojo> compile = new CompileMojoRule<>(
+      CompileProjectMojo.GOAL){
     @Override
     protected void before() throws Throwable {
       super.before();
@@ -62,16 +62,16 @@ public class TestCompileProjectMojo extends BaseEngineProjectMojoTest {
     assertThat(findFiles(wsProcDir, "java")).hasSize(1);
 
     assertThat(findFiles(classDir, "txt"))
-            .as("classes directory must only be cleand by the builder before compilation if class files are found")
-            .hasSize(1);
+        .as("classes directory must only be cleand by the builder before compilation if class files are found")
+        .hasSize(1);
     assertThat(findFiles(classDir, "class"))
-            .as("compiled classes must exist. but not contain any test class or old class files.")
-            .hasSize(4);
+        .as("compiled classes must exist. but not contain any test class or old class files.")
+        .hasSize(4);
 
     testMojo.execute();
     assertThat(findFiles(classDir, "class"))
-            .as("compiled classes must contain test resources as well")
-            .hasSize(5);
+        .as("compiled classes must contain test resources as well")
+        .hasSize(5);
   }
 
   private static List<Path> findFiles(Path dir, String fileExtension) throws IOException {
@@ -80,8 +80,8 @@ public class TestCompileProjectMojo extends BaseEngineProjectMojoTest {
     }
     try (var stream = Files.walk(dir)) {
       return stream
-              .filter(p -> p.getFileName().toString().endsWith("." + fileExtension))
-              .toList();
+          .filter(p -> p.getFileName().toString().endsWith("." + fileExtension))
+          .toList();
     }
   }
 

--- a/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToEngineMojo.java
@@ -56,8 +56,8 @@ public class TestDeployToEngineMojo {
     mockEngineDeployThread.failOnException();
 
     assertThat(deployedIar)
-            .as("IAR should not exist in engine deploy directory")
-            .doesNotExist();
+        .as("IAR should not exist in engine deploy directory")
+        .doesNotExist();
   }
 
   @Test
@@ -86,8 +86,8 @@ public class TestDeployToEngineMojo {
     mockEngineDeployThread.failOnException();
 
     assertThat(deployedIar)
-            .as("IAR should not exist in engine deploy directory")
-            .doesNotExist();
+        .as("IAR should not exist in engine deploy directory")
+        .doesNotExist();
   }
 
   @Test
@@ -108,12 +108,12 @@ public class TestDeployToEngineMojo {
     Callable<Void> engineOperation = () -> {
       assertThat(deploymentOptionsFile).exists();
       assertThat(deploymentOptionsFile).hasContent(
-                      """
-                      deployTestUsers: "TRUE"
-                      target:
-                        version: RELEASED
-                        state: INACTIVE
-                        fileFormat: EXPANDED""");
+          """
+            deployTestUsers: "TRUE"
+            target:
+              version: RELEASED
+              state: INACTIVE
+              fileFormat: EXPANDED""");
       Files.delete(deploymentOptionsFile);
       assertThat(deployedIar).exists();
       Files.delete(deployedIar);
@@ -124,8 +124,8 @@ public class TestDeployToEngineMojo {
     mockEngineDeployThread.failOnException();
 
     assertThat(deployedIar)
-            .as("IAR should not exist in engine deploy directory")
-            .doesNotExist();
+        .as("IAR should not exist in engine deploy directory")
+        .doesNotExist();
   }
 
   @Test
@@ -155,14 +155,14 @@ public class TestDeployToEngineMojo {
 
   private static Path getTarget(Path iar, DeployToEngineMojo mojo) {
     return mojo.deployEngineDirectory
-            .resolve(mojo.deployDirectory)
-            .resolve(mojo.deployToEngineApplication)
-            .resolve(iar.getFileName().toString());
+        .resolve(mojo.deployDirectory)
+        .resolve(mojo.deployToEngineApplication)
+        .resolve(iar.getFileName().toString());
   }
 
   @Rule
-  public ProjectMojoRule<DeployToEngineMojo> rule = new ProjectMojoRule<DeployToEngineMojo>(
-          Path.of("src/test/resources/base"), DeployToEngineMojo.GOAL) {
+  public ProjectMojoRule<DeployToEngineMojo> rule = new ProjectMojoRule<>(
+      Path.of("src/test/resources/base"), DeployToEngineMojo.GOAL){
     @Override
     protected void before() throws Throwable {
       super.before();
@@ -203,7 +203,7 @@ public class TestDeployToEngineMojo {
     }
 
     public void execute(Callable<Void> delayedFunction) {
-      thread = new Thread() {
+      thread = new Thread(){
         @Override
         public void run() {
           try {

--- a/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToRunningEngine.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToRunningEngine.java
@@ -98,7 +98,7 @@ public class TestDeployToRunningEngine extends BaseEngineProjectMojoTest {
   public void canDeployRemoteIar_encryptedSettingsPassword() throws Exception {
     addServerConnection("{VUpeDRRbfD4Hmk9WLKzhqLkLttTCsWfLtr75Nt9K/3k=}");
     System.setProperty("settings.security",
-            TestDeployToRunningEngine.class.getResource("settings-security.xml").getPath());
+        TestDeployToRunningEngine.class.getResource("settings-security.xml").getPath());
     deployIarRemoteAndAssert();
   }
 
@@ -120,15 +120,15 @@ public class TestDeployToRunningEngine extends BaseEngineProjectMojoTest {
       System.setOut(originalOut);
       startedProcess = mojo.startEngine();
       deployMojo.deployEngineUrl = (String) rule.project.getProperties()
-              .get(EngineControl.Property.TEST_ENGINE_URL);
+          .get(EngineControl.Property.TEST_ENGINE_URL);
       System.setOut(new PrintStream(outContent));
 
       deployMojo.execute();
 
       assertThat(outContent.toString()).contains("Start deploying project(s) of file")
-              .contains("Application: test")
-              .contains("Deploying users ...")
-              .doesNotContain("deployDirectory is set but will not be used for HTTP Deployment.");
+          .contains("Application: test")
+          .contains("Deploying users ...")
+          .doesNotContain("deployDirectory is set but will not be used for HTTP Deployment.");
     } finally {
       kill(startedProcess);
     }
@@ -136,9 +136,9 @@ public class TestDeployToRunningEngine extends BaseEngineProjectMojoTest {
 
   private static Path getTarget(Path iar, DeployToEngineMojo mojo) {
     return mojo.deployEngineDirectory
-            .resolve(mojo.deployDirectory)
-            .resolve(mojo.deployToEngineApplication)
-            .resolve(iar.getFileName().toString());
+        .resolve(mojo.deployDirectory)
+        .resolve(mojo.deployToEngineApplication)
+        .resolve(iar.getFileName().toString());
   }
 
   private static void kill(Process startedProcess) {
@@ -148,11 +148,11 @@ public class TestDeployToRunningEngine extends BaseEngineProjectMojoTest {
   }
 
   @Rule
-  public RunnableEngineMojoRule<StartTestEngineMojo> rule = new RunnableEngineMojoRule<StartTestEngineMojo>(
-          StartTestEngineMojo.GOAL);
+  public RunnableEngineMojoRule<StartTestEngineMojo> rule = new RunnableEngineMojoRule<>(
+      StartTestEngineMojo.GOAL);
 
   @Rule
-  public ProjectMojoRule<DeployToEngineMojo> deployRule = new ProjectMojoRule<DeployToEngineMojo>(
-          Path.of("src/test/resources/base"), DeployToEngineMojo.GOAL);
+  public ProjectMojoRule<DeployToEngineMojo> deployRule = new ProjectMojoRule<>(
+      Path.of("src/test/resources/base"), DeployToEngineMojo.GOAL);
 
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToTestEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToTestEngineMojo.java
@@ -51,14 +51,14 @@ public class TestDeployToTestEngineMojo {
     Files.createFile(builtTarget.resolve("alreadyPacked.iar"));
 
     var appZip = mojo.createFullAppZip(List.of(
-            Files.createFile(workspace.resolve("demo.iar")),
-            Files.createFile(workspace.resolve("demoTest.iar")),
-            reactorProject,
-            builtTarget.getParent()));
+        Files.createFile(workspace.resolve("demo.iar")),
+        Files.createFile(workspace.resolve("demoTest.iar")),
+        reactorProject,
+        builtTarget.getParent()));
     assertThat(appZip.getFileName().toString()).isEqualTo("myApp-app.zip");
     assertThat(DeployToTestEngineMojo.findPackedIar(builtTarget.getParent())).isPresent();
     assertThat(getRootFiles(appZip))
-            .containsOnly("demo.iar", "demoTest.iar", "myReactorProject", "alreadyPacked.iar");
+        .containsOnly("demo.iar", "demoTest.iar", "myReactorProject", "alreadyPacked.iar");
   }
 
   private static List<String> getRootFiles(Path zip) throws IOException {
@@ -67,8 +67,8 @@ public class TestDeployToTestEngineMojo {
       Path root = zipFsCr.getPath("/");
       try (Stream<Path> paths = Files.list(root)) {
         return paths
-                .map(child -> child.getFileName().toString())
-                .collect(Collectors.toList());
+            .map(child -> child.getFileName().toString())
+            .collect(Collectors.toList());
       }
     }
   }
@@ -80,6 +80,6 @@ public class TestDeployToTestEngineMojo {
 
   @Rule
   public ProjectMojoRule<DeployToTestEngineMojo> deploy = new ProjectMojoRule<>(
-          Path.of("src/test/resources/base"), DeployToTestEngineMojo.TEST_GOAL);
+      Path.of("src/test/resources/base"), DeployToTestEngineMojo.TEST_GOAL);
 
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/engine/TestClasspathJar.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/engine/TestClasspathJar.java
@@ -53,8 +53,8 @@ class TestClasspathJar {
 
       String manifest = new String(in.readAllBytes(), StandardCharsets.UTF_8);
       assertThat(manifest)
-              .as("Manifest should not start with a whitespace or it will not be interpreted by the JVM")
-              .startsWith("Manifest-Version:");
+          .as("Manifest should not start with a whitespace or it will not be interpreted by the JVM")
+          .startsWith("Manifest-Version:");
     }
   }
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/engine/TestEngineControl.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/engine/TestEngineControl.java
@@ -30,8 +30,8 @@ import ch.ivyteam.ivy.maven.test.StopTestEngineMojo;
 public class TestEngineControl extends BaseEngineProjectMojoTest {
 
   @Rule
-  public RunnableEngineMojoRule<StopTestEngineMojo> rule = new RunnableEngineMojoRule<StopTestEngineMojo>(
-          StopTestEngineMojo.GOAL);
+  public RunnableEngineMojoRule<StopTestEngineMojo> rule = new RunnableEngineMojoRule<>(
+      StopTestEngineMojo.GOAL);
 
   @Test
   public void resolveEngineState() throws MojoExecutionException {

--- a/src/test/java/ch/ivyteam/ivy/maven/engine/download/TestLatestMinorVersionRange.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/engine/download/TestLatestMinorVersionRange.java
@@ -14,7 +14,7 @@ class TestLatestMinorVersionRange {
     assertThat(new LatestMinorVersionRange("8.1.0").get().toString()).isEqualTo("[8.1.0,8.2.0)");
 
     assertThatThrownBy(() -> new LatestMinorVersionRange("8").get())
-      .isInstanceOf(RuntimeException.class)
-      .hasMessage("Could not calculate version spec from 8");
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Could not calculate version spec from 8");
   }
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/log/LogCollector.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/log/LogCollector.java
@@ -36,8 +36,8 @@ public class LogCollector implements Log {
   private final List<LogEntry> errors = new ArrayList<>();
 
   public static class LogEntry {
-    private String message;
-    private Throwable error;
+    private final String message;
+    private final Throwable error;
 
     private LogEntry(String message, Throwable error) {
       if (message == null) {
@@ -75,8 +75,7 @@ public class LogCollector implements Log {
   }
 
   public List<LogEntry> getLogs() {
-    List<LogEntry> logs = new ArrayList<>();
-    logs.addAll(debuggings);
+    List<LogEntry> logs = new ArrayList<>(debuggings);
     logs.addAll(infos);
     logs.addAll(warnings);
     logs.addAll(errors);

--- a/src/test/java/ch/ivyteam/ivy/maven/test/TestEngineControlEngineDirectory.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/test/TestEngineControlEngineDirectory.java
@@ -12,8 +12,8 @@ import ch.ivyteam.ivy.maven.test.AbstractIntegrationTestMojo.TestEngineLocation;
 public class TestEngineControlEngineDirectory extends BaseEngineProjectMojoTest {
 
   @Rule
-  public RunnableEngineMojoRule<StopTestEngineMojo> rule = new RunnableEngineMojoRule<StopTestEngineMojo>(
-          StopTestEngineMojo.GOAL);
+  public RunnableEngineMojoRule<StopTestEngineMojo> rule = new RunnableEngineMojoRule<>(
+      StopTestEngineMojo.GOAL);
 
   @Test
   public void engineControl_engineDir_doesNotExist() throws Exception {

--- a/src/test/java/ch/ivyteam/ivy/maven/test/TestSetupIvyTestPropertiesMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/test/TestSetupIvyTestPropertiesMojo.java
@@ -48,14 +48,14 @@ public class TestSetupIvyTestPropertiesMojo extends BaseEngineProjectMojoTest {
   public void engineClasspathIsSharedAsProperty() throws Exception {
     var mojo = rule.getMojo();
     assertThat(getProperty(Property.IVY_ENGINE_CLASSPATH))
-            .as("used classpath has not been evaluated.")
-            .isNullOrEmpty();
+        .as("used classpath has not been evaluated.")
+        .isNullOrEmpty();
     assertThat(getProperty(Property.MAVEN_TEST_ARGLINE)).isNullOrEmpty();
 
     mojo.execute();
     assertThat(getProperty(Property.IVY_ENGINE_CLASSPATH))
-            .as("used classpath must be shared as property so that other mojos can access it")
-            .isNotEmpty();
+        .as("used classpath must be shared as property so that other mojos can access it")
+        .isNotEmpty();
   }
 
   @Test
@@ -77,11 +77,11 @@ public class TestSetupIvyTestPropertiesMojo extends BaseEngineProjectMojoTest {
 
     MavenProject project = rule.getMojo().project;
     assertThat(project.getBuild().getTestOutputDirectory())
-            .isEqualTo(project.getBasedir().toPath().resolve("classes-test").toAbsolutePath().toString());
+        .isEqualTo(project.getBasedir().toPath().resolve("classes-test").toAbsolutePath().toString());
     assertThat(project.getProperties().get(Property.MAVEN_TEST_ADDITIONAL_CLASSPATH))
-            .isEqualTo("${" + Property.IVY_TEST_VM_RUNTIME + "},"
-                    + "${" + Property.IVY_ENGINE_CLASSPATH + "},"
-                    + "${" + Property.IVY_PROJECT_IAR_CLASSPATH + "}");
+        .isEqualTo("${" + Property.IVY_TEST_VM_RUNTIME + "},"
+            + "${" + Property.IVY_ENGINE_CLASSPATH + "},"
+            + "${" + Property.IVY_PROJECT_IAR_CLASSPATH + "}");
   }
 
   @Test
@@ -91,13 +91,13 @@ public class TestSetupIvyTestPropertiesMojo extends BaseEngineProjectMojoTest {
     MavenProject project = rule.getMojo().project;
     String vmRtEntry = project.getProperties().getProperty(Property.IVY_TEST_VM_RUNTIME);
     Properties props = new Properties();
-    try (var loader = new URLClassLoader(new URL[] { Path.of(vmRtEntry).toUri().toURL()}, null);
-         var is = loader.getResourceAsStream(IvyTestRuntime.RUNTIME_PROPS_RESOURCE)) {
+    try (var loader = new URLClassLoader(new URL[] {Path.of(vmRtEntry).toUri().toURL()}, null);
+        var is = loader.getResourceAsStream(IvyTestRuntime.RUNTIME_PROPS_RESOURCE)) {
       props.load(is);
     }
     assertThat(props.getProperty(Key.PRODUCT_DIR)).isNotEmpty();
     assertThat(props.getProperty(Key.PROJECT_LOCATIONS))
-            .isEqualTo("<" + rule.getMojo().project.getBasedir().toPath().toUri() + ">");
+        .isEqualTo("<" + rule.getMojo().project.getBasedir().toPath().toUri() + ">");
   }
 
   @Test
@@ -126,8 +126,8 @@ public class TestSetupIvyTestPropertiesMojo extends BaseEngineProjectMojoTest {
     private void writeTestClasspathJar() throws IOException {
       var classPathJar = new SharedFile(getMojo().project).getEngineClasspathJar();
       new ClasspathJar(classPathJar).createFileEntries(List.of(
-              Files.createTempFile("dummy", ".jar").toFile(),
-              Files.createTempFile("dummy2", ".jar").toFile()));
+          Files.createTempFile("dummy", ".jar").toFile(),
+          Files.createTempFile("dummy2", ".jar").toFile()));
     }
 
     private void writeTestCompileResult() throws IOException {

--- a/src/test/java/ch/ivyteam/ivy/maven/test/TestShareIntegrationTestPropertiesMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/test/TestShareIntegrationTestPropertiesMojo.java
@@ -55,7 +55,7 @@ public class TestShareIntegrationTestPropertiesMojo extends BaseEngineProjectMoj
     mojo.execute();
     String argLine = (String) props.get(SetupIntegrationTestPropertiesMojo.FAILSAFE_ARGLINE_PROPERTY);
     assertThat(argLine)
-            .startsWith("-Dtest.engine.url=http://127.0.0.1:9999 -Dtest.engine.log=/var/logs/ivy.log -Dtest.engine.app=myTstApp")
-            .contains(" --add-opens=");
+        .startsWith("-Dtest.engine.url=http://127.0.0.1:9999 -Dtest.engine.log=/var/logs/ivy.log -Dtest.engine.app=myTstApp")
+        .contains(" --add-opens=");
   }
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/test/TestStartEngine.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/test/TestStartEngine.java
@@ -47,8 +47,8 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
     try {
       startedProcess = mojo.startEngine();
       assertThat(getProperty(EngineControl.Property.TEST_ENGINE_URL))
-              .startsWith("http://")
-              .endsWith("/");
+          .startsWith("http://")
+          .endsWith("/");
       assertThat(Path.of(getProperty(EngineControl.Property.TEST_ENGINE_LOG))).exists();
     } finally {
       kill(startedProcess);
@@ -69,7 +69,7 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
     mojo.testEngine = TestEngineLocation.MODIFY_EXISTING;
     mojo.engineDirectory = Files.createTempDirectory("test");
     assertThat(mojo.engineToTarget()).as("MODIFY_EXISTING set and using configured engine do not copy")
-            .isFalse();
+        .isFalse();
   }
 
   @Test
@@ -93,7 +93,7 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
     mojo.testEngine = TestEngineLocation.COPY_FROM_TEMPLATE;
     mojo.engineDirectory = Files.createTempDirectory("test");
     assertThat(mojo.engineToTarget()).as("COPY_FROM_TEMPLATE set and using configured engine do copy")
-            .isTrue();
+        .isTrue();
   }
 
   @Test
@@ -117,7 +117,7 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
     mojo.testEngine = TestEngineLocation.COPY_FROM_CACHE;
     mojo.engineDirectory = Files.createTempDirectory("test");
     assertThat(mojo.engineToTarget()).as("COPY_FROM_CACHE set and using configured engine do not copy")
-            .isFalse();
+        .isFalse();
   }
 
   @Test
@@ -135,8 +135,8 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
       mojo.testEngine = TestEngineLocation.COPY_FROM_TEMPLATE;
       var engineDirTarget = mojo.getEngineDir(mojo.project);
       assertThat(engineDirTarget)
-        .endsWithRaw(Path.of("target").resolve("ivyEngine"))
-        .doesNotExist();
+          .endsWithRaw(Path.of("target").resolve("ivyEngine"))
+          .doesNotExist();
 
       startedProcess = mojo.startEngine();
       assertThat(engineDirTarget).exists();
@@ -155,8 +155,8 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
     try {
       var engineDirTarget = mojo.getEngineDir(mojo.project);
       assertThat(engineDirTarget)
-        .endsWithRaw(Path.of("target").resolve("ivyEngine"))
-        .doesNotExist();
+          .endsWithRaw(Path.of("target").resolve("ivyEngine"))
+          .doesNotExist();
       assertThat(log.getWarnings().toString()).doesNotContain("Skipping copy");
 
       startedProcess = mojo.startEngine();
@@ -193,16 +193,14 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
 
   private void assertFileExecutable(Path file) {
     assertThat(file)
-            .exists()
-            .isExecutable();
+        .exists()
+        .isExecutable();
   }
 
   private static void kill(Process startedProcess) {
     if (startedProcess != null) {
       startedProcess.destroy();
-      await().untilAsserted(() ->
-        assertThat(startedProcess.isAlive()).as("gracefully wait on stop").isFalse()
-      );
+      await().untilAsserted(() -> assertThat(startedProcess.isAlive()).as("gracefully wait on stop").isFalse());
     }
   }
 
@@ -211,8 +209,8 @@ public class TestStartEngine extends BaseEngineProjectMojoTest {
   }
 
   @Rule
-  public RunnableEngineMojoRule<StartTestEngineMojo> rule = new RunnableEngineMojoRule<StartTestEngineMojo>(
-          StartTestEngineMojo.GOAL) {
+  public RunnableEngineMojoRule<StartTestEngineMojo> rule = new RunnableEngineMojoRule<>(
+      StartTestEngineMojo.GOAL){
     @Override
     protected void before() throws Throwable {
       super.before();

--- a/src/test/java/ch/ivyteam/ivy/maven/util/TestPathUtils.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/util/TestPathUtils.java
@@ -11,7 +11,6 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-
 class TestPathUtils {
 
   @Test

--- a/src/test/java/ch/ivyteam/ivy/maven/validate/TestValidateMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/validate/TestValidateMojo.java
@@ -16,13 +16,12 @@ import org.junit.Test;
 import ch.ivyteam.ivy.maven.ProjectMojoRule;
 import ch.ivyteam.ivy.maven.log.LogCollector;
 
-
 public class TestValidateMojo {
   private ValidateMojo mojo;
 
   @Rule
-  public ProjectMojoRule<ValidateMojo> rule = new ProjectMojoRule<ValidateMojo>(
-          Path.of("src/test/resources/base"), ValidateMojo.GOAL) {
+  public ProjectMojoRule<ValidateMojo> rule = new ProjectMojoRule<>(
+      Path.of("src/test/resources/base"), ValidateMojo.GOAL){
     @Override
     protected void before() throws Throwable {
       super.before();
@@ -39,9 +38,9 @@ public class TestValidateMojo {
     mojo.validateConsistentPluginVersion(List.of(p1, p2));
     assertThat(log.getDebug()).hasSize(2);
     assertThat(log.getDebug().get(0).toString())
-      .contains("com.axonivy.ivy.ci:project-build-plugin:12.0.0 configured in MavenProject: group:project1:12.0.0-SNAPSHOT");
+        .contains("com.axonivy.ivy.ci:project-build-plugin:12.0.0 configured in MavenProject: group:project1:12.0.0-SNAPSHOT");
     assertThat(log.getDebug().get(1).toString())
-      .contains("com.axonivy.ivy.ci:project-build-plugin:12.0.0 configured in MavenProject: group:project2:12.0.0-SNAPSHOT");
+        .contains("com.axonivy.ivy.ci:project-build-plugin:12.0.0 configured in MavenProject: group:project2:12.0.0-SNAPSHOT");
     assertThat(log.getErrors()).isEmpty();
   }
 
@@ -52,13 +51,13 @@ public class TestValidateMojo {
     var p1 = createMavenProject("project1", "12.0.0");
     var p2 = createMavenProject("project2", "12.0.1");
     assertThatThrownBy(() -> mojo.validateConsistentPluginVersion(List.of(p1, p2)))
-      .isInstanceOf(MojoExecutionException.class);
+        .isInstanceOf(MojoExecutionException.class);
     assertThat(log.getErrors()).hasSize(1);
     assertThat(log.getErrors().get(0).toString())
-      .isEqualTo("""
-        Several versions of project-build-plugins are configured [12.0.0, 12.0.1]:
-        12.0.0 -> [project1]
-        12.0.1 -> [project2]""");
+        .isEqualTo("""
+          Several versions of project-build-plugins are configured [12.0.0, 12.0.1]:
+          12.0.0 -> [project1]
+          12.0.1 -> [project2]""");
   }
 
   private MavenProject createMavenProject(String projectId, String version) {


### PR DESCRIPTION
Done by Eclipse's 'Source Clean Up' function with the options enabled:
- Change non static accesses to static members using declaring type
- Change indirect accesses to static members to direct accesses (accesses through subtypes)
- Convert control statement bodies to block
- Convert to enhanced 'for' loops only if the loop variable is used
- Convert to enhanced 'for' loops
- Convert if/else if/else chain to switch
- Add elements in collections without loop
- Add final modifier to private fields
- Use instanceof keyword instead of Class.isInstance()
- Exit loop earlier
- Make inner classes static where possible
- Convert StringBuffer to StringBuilder for local variables
- Use String.replace() instead of String.replaceAll() when possible
- String.isBlank() rather than String.strip().isEmpty()
- Use lazy logical operator (&& and ||)
- Primitive comparison
- Primitive parsing
- Primitive serialization
- Use boolean literals instead of Boolean.TRUE/FALSE when used as a primitive
- Remove unused imports
- Add missing '@OverRide' annotations
- Add missing '@OverRide' annotations to implementations of interface methods
- Add missing '@deprecated' annotations
- Remove unnecessary casts
- Remove redundant modifiers
- Remove redundant semicolons
- Implicit comparator
- Remove unnecessary array creation for varargs
- Create array with curly
- Remove variable assignment before return
- Convert loop into if
- Remove unnecessary '$NON-NLS$' tags
- Organize imports
- Format source code
- Remove trailing white spaces on all lines
- Remove redundant String.substring() parameter
- Use Arrays.fill() when possible
- Remove overridden assignment
- Remove redundant super() call in constructor
- Remove unreachable block
- Operate on Maps directly
- Initialize collection at creation
- Initialize map at creation
- Avoid Object.equals() or String.equalsIgnoreCase() on null objects
- Compare to zero
- Pull out a duplicate 'if' from an if/else
- Use pattern matching for instanceof
- Convert to switch expression where possible
- Simplify lambda expression and method reference syntax
- Use Comparator.comparing()
- Use String.join()
- Use diamond operator