### PR TITLE
Generate sbom, upload it to dtrack and provide it via maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,23 @@
           <skipDeletedFiles>true</skipDeletedFiles>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+              <goals>
+                <goal>makeBom</goal>
+               </goals>
+           </execution>
+        </executions>
+        <configuration>
+          <outputFormat>json</outputFormat>
+          <includeLicenseText>true</includeLicenseText>
+        </configuration>
+      </plugin>
     </plugins>
     
     <pluginManagement>


### PR DESCRIPTION
- Generate sbom
- Upload it to dtrack
- This will automatically attach the json as part of the official release

```
--- install:3.1.2:install (default-install) @ project-build-plugin ---
[INFO] Installing /home/alex/git/project-build-plugin/pom.xml to /home/alex/.m2/repository/com/axonivy/ivy/ci/project-build-plugin/13.1.0-SNAPSHOT/project-build-plugin-13.1.0-SNAPSHOT.pom
[INFO] Installing /home/alex/git/project-build-plugin/target/project-build-plugin-13.1.0-SNAPSHOT.jar to /home/alex/.m2/repository/com/axonivy/ivy/ci/project-build-plugin/13.1.0-SNAPSHOT/project-build-plugin-13.1.0-SNAPSHOT.jar
[INFO] Installing /home/alex/git/project-build-plugin/target/bom.json to /home/alex/.m2/repository/com/axonivy/ivy/ci/project-build-plugin/13.1.0-SNAPSHOT/project-build-plugin-13.1.0-SNAPSHOT-cyclonedx.json
```

I think this is the smartest way to provide bom files for maven artifacts. project-build-plugin won't be provided via Designer/Engine so there I don't want to include the bom of project-build-plugin there.

The bom generation is now running in every build, but it's quite fast. I think this is ok.

will merge it to LTS12 and LTS10
