### PR TITLE
renovat: re-state base-branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,11 @@
     "local>axonivy/renovate-config",
     "schedule:earlyMondays"
   ],
+  "baseBranches": [
+    "master",
+    "release/12.0",
+    "release/10.0"
+  ],
   "packageRules": [
     {
       "matchBaseBranches": [


### PR DESCRIPTION
seems like we can't inherit them from our global renovate-config