### PR TITLE
dynamic pattern to cover new release branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,8 +6,7 @@
   ],
   "baseBranches": [
     "master",
-    "release/12.0",
-    "release/10.0"
+    "/^release\\/[0-9]{2}\\.[0-9]+/"
   ],
   "packageRules": [
     {
@@ -30,8 +29,7 @@
     },
     {
       "matchBaseBranches": [
-        "release/12.0",
-        "release/10.0"
+        "/^release\\/[0-9]{2}\\.[0-9]+/"
       ],
       "matchDepTypes": [
         "build",


### PR DESCRIPTION
- at least 2 leading digits: we only maintain 10.0 and newer