### PR TITLE
XIVY-16339 set maven dependency resolution to runtime

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/MavenDependencyMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/MavenDependencyMojo.java
@@ -47,7 +47,7 @@ import ch.ivyteam.ivy.maven.util.MavenDependencies;
  *
  * @since 9.2.0
  */
-@Mojo(name = MavenDependencyMojo.GOAL, requiresDependencyResolution = ResolutionScope.COMPILE)
+@Mojo(name = MavenDependencyMojo.GOAL, requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM)
 public class MavenDependencyMojo extends AbstractProjectCompileMojo {
   public static final String GOAL = "maven-dependency";
 


### PR DESCRIPTION
If a project gets exported using the designer, dependencies with scope `compile`, `system` and `runtime` are included.
see `ch.ivyteam.ivy.java.restricted.classpath.MavenDependencies.SCOPES`

Things are different with the project build plugin, which includes `compile`, `system` and `provided`. The problem is that we define ivy-api dependency with scope `provided` in the ivy project and this would make the iar quite large ;)

So I suggest to switch from
`COMPILE = compile + system + provided dependencies`
to
`RUNTIME_PLUS_SYSTEM = compile + system + runtime dependencies`
