### PR TITLE
fix: auto release publisher failed due to broken workflow reference

### DIFF
--- a/.github/workflows/tag-publisher.yml
+++ b/.github/workflows/tag-publisher.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build:
-    uses: ./.github/workflows/draft-pub.yml
+    uses: ./.github/workflows/draft-publisher.yml
     with:
       version: ${{ inputs.tag }}
       # The 'publish' input parameter is used to control whether the release should be published automatically.


### PR DESCRIPTION
auto-publishing of our 13.1.0 release failed, this time due to the release-drafter :man_shrugging: 

https://github.com/axonivy/project-build-plugin/actions/runs/15047692194

![failed-release-draft-publisher](https://github.com/user-attachments/assets/4bd35233-1417-4bb0-afd1-f3134ce89d54)
