### PR TITLE
XIVY-16828 Process issues not reported as [WARNING]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <properties>
     <java.version>21</java.version>
     <maven.version>3.9.9</maven.version>
-    <slf4j.version>2.0.13</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <junit-jupiter.version>5.12.2</junit-jupiter.version>
     <site.path>snapshot</site.path>
     <other.site.path>release</other.site.path>

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/Slf4jSimpleEngineProperties.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/Slf4jSimpleEngineProperties.java
@@ -16,6 +16,7 @@
 
 package ch.ivyteam.ivy.maven.engine;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
@@ -65,6 +66,19 @@ public class Slf4jSimpleEngineProperties {
     // only warnings from any logger used by ivy third parties (e.g.
     // org.apache.myfaces.xxx, org.apache.cxf, ...)
     System.setProperty(DEFAULT_LOG_LEVEL, Level.WARNING);
+
+    // remain in same stream as the Maven CLI; don't use the default 'System.err'
+    System.setProperty(SimpleLogger.LOG_FILE_KEY, "System.out");
+  }
+
+  public static void enforceSimpleConfigReload() {
+    try {
+      Method initMethod = SimpleLogger.class.getDeclaredMethod("init");
+      initMethod.setAccessible(true);
+      initMethod.invoke(null);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
   }
 
   public static void reset() {

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/Slf4jSimpleEngineProperties.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/Slf4jSimpleEngineProperties.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
-import org.slf4j.simple.SimpleLogger;
+import org.slf4j.impl.SimpleLogger;
 
 /**
  * Sets the logging properties for the ivy engine.
@@ -105,7 +105,7 @@ public class Slf4jSimpleEngineProperties {
   }
 
   /**
-   * Valid levels as documented in {@link org.slf4j.simple.SimpleLogger}
+   * Valid levels as documented in {@link SimpleLogger}
    */
   interface Level {
     String TRACE = "trace";

--- a/src/test/java/ch/ivyteam/ivy/maven/TestSlf4jWarningConfiguration.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestSlf4jWarningConfiguration.java
@@ -2,12 +2,24 @@ package ch.ivyteam.ivy.maven;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.slf4j.simple.SimpleLogger;
 
 import ch.ivyteam.ivy.maven.engine.Slf4jSimpleEngineProperties;
 
 class TestSlf4jWarningConfiguration {
+
+  @BeforeEach
+  void setup() {
+    Slf4jSimpleEngineProperties.install();
+  }
+
   /*
    * XIVY-3123 Streamline the log output to be maven-like, instead of logging
    * [WARN] we want [WARNING]. This allows us to use the maven log parser on our
@@ -15,9 +27,29 @@ class TestSlf4jWarningConfiguration {
    */
   @Test
   void mavenLikeWarning() {
-    Slf4jSimpleEngineProperties.install();
     assertThat(System.getProperty(SimpleLogger.WARN_LEVEL_STRING_KEY))
         .as("SLF4J warning string is not maven-like [WARNING]")
         .isEqualTo("WARNING");
   }
+
+  @Test
+  void mavenLoggerWarningOut() throws IOException {
+    var original = System.out;
+    try (var bos = new ByteArrayOutputStream();
+        var memoryOut = new PrintStream(bos);) {
+      System.setOut(memoryOut);
+
+      var logger = LoggerFactory.getLogger("maven.cli");
+      logger.warn("hey");
+
+      String out = bos.toString();
+      assertThat(out)
+          .as("WARNING bracket matches Maven CLI")
+          .startsWith("[WARNING] hey");
+
+    } finally {
+      System.setOut(original);
+    }
+  }
+
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/TestSlf4jWarningConfiguration.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestSlf4jWarningConfiguration.java
@@ -9,7 +9,7 @@ import java.io.PrintStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
-import org.slf4j.simple.SimpleLogger;
+import org.slf4j.impl.SimpleLogger;
 
 import ch.ivyteam.ivy.maven.engine.Slf4jSimpleEngineProperties;
 

--- a/src/test/resources/base/processes/myWebService.p.json
+++ b/src/test/resources/base/processes/myWebService.p.json
@@ -16,7 +16,7 @@
           "params" : [
             { "name" : "myText", "type" : "String", "desc" : "" }
           ],
-          "map" : { }
+          "code" : "//TEMPLATE!!"
         }
       },
       "visual" : {


### PR DESCRIPTION
enables our configuration for `[WARNING]` prefixed brackets, just like maven does, .... while the default of slf4j is `[WARN]`.

since slf4j 2.x half-way removed that feature, we have to downgrade to 1.7.x:
- maven CLI also uses slf4j.simpl 1.7
- Nevertheless, I'll try to [discuss](https://github.com/qos-ch/slf4j/pull/463) the re-introduction of the 'warningString' configuration on the slf4j repos. Since the configuration values are still [documented](https://github.com/qos-ch/slf4j/blob/183aaa507040ce6c61f70762c13e7d11aa4fd54e/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java#L203C32-L203C53) and in the code, but they are no longer interpreted :shrug: 

![maven39-slf4j1](https://github.com/user-attachments/assets/49c48064-94b0-4b26-a964-c1e8f88cf24c)
