### PR TITLE
updateDoc:default-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ Wait until the maven central release is available: this may take several hours u
 
 - Inform team-wawa @Teams to update to update Portal onto the latest project-build-plugin version!
 
-- Raise ch.ivyteam.ivy.library.IvyProjectBuildPlugin.DEFAULT_VERSION in ivy core
-
 ## License
 
 The Apache License, Version 2.0


### PR DESCRIPTION
default plugin updates have been automated a while a go, it's part of the raise-ivy-project-build-plugin version build.