### PR TITLE
fix: deploy-to-engine mojo fails due to missing plexus-sec-dispatcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
       <!--NOT provided: will fail on consuming builds -->
     </dependency>
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-sec-dispatcher</artifactId>
+      <version>2.0</version>
+      <!--NOT provided: will fail on consuming builds -->
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>3.6.4</version>


### PR DESCRIPTION
I changed the selenium-test of release/10 to work with the latest available 10.0.18-SNAPSHOT and it did no longer work due to the absence of the plexus-sec-dispatcher. See https://github.com/axonivy/core/pull/9153

and https://jenkins.ivyteam.io/job/core_test-selenium/job/useSnap/3
I think we lost it by raising a peer dependency, which was importing sec-dispatcher, at any rate was the last official release 10.0.17 still ok.

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:51 min
[INFO] Finished at: 2025-06-06T16:54:55+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT:deploy-to-engine (test.webserver.deploy.app) on project selenium-test: Execution test.webserver.deploy.app of goal com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT:deploy-to-engine failed: A required class was missing while executing com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT:deploy-to-engine: org/sonatype/plexus/components/sec/dispatcher/SecDispatcher
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/build/.m2/repository/com/axonivy/ivy/ci/project-build-plugin/10.0.18-SNAPSHOT/project-build-plugin-10.0.18-SNAPSHOT.jar
[ERROR] urls[1] = file:/home/build/.m2/repository/org/apache/maven/shared/maven-filtering/3.4.0/maven-filtering-3.4.0.jar
[ERROR] urls[2] = file:/home/build/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
[ERROR] urls[3] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-utils/3.6.0/plexus-utils-3.6.0.jar
[ERROR] urls[4] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-xml/3.0.1/plexus-xml-3.0.1.jar
[ERROR] urls[5] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.jar
[ERROR] urls[6] = file:/home/build/.m2/repository/org/apache/maven/wagon/wagon-http/3.5.3/wagon-http-3.5.3.jar
[ERROR] urls[7] = file:/home/build/.m2/repository/org/apache/maven/wagon/wagon-http-shared/3.5.3/wagon-http-shared-3.5.3.jar
[ERROR] urls[8] = file:/home/build/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.36/jcl-over-slf4j-1.7.36.jar
[ERROR] urls[9] = file:/home/build/.m2/repository/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar
[ERROR] urls[10] = file:/home/build/.m2/repository/com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar
[ERROR] urls[11] = file:/home/build/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
[ERROR] urls[12] = file:/home/build/.m2/repository/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar
[ERROR] urls[13] = file:/home/build/.m2/repository/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.jar
[ERROR] urls[14] = file:/home/build/.m2/repository/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar
[ERROR] urls[15] = file:/home/build/.m2/repository/org/apache/commons/commons-lang3/3.17.0/commons-lang3-3.17.0.jar
[ERROR] urls[16] = file:/home/build/.m2/repository/commons-io/commons-io/2.19.0/commons-io-2.19.0.jar
[ERROR] urls[17] = file:/home/build/.m2/repository/org/apache/commons/commons-exec/1.5.0/commons-exec-1.5.0.jar
[ERROR] urls[18] = file:/home/build/.m2/repository/net/lingala/zip4j/zip4j/2.11.5/zip4j-2.11.5.jar
[ERROR] urls[19] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-archiver/4.10.0/plexus-archiver-4.10.0.jar
[ERROR] urls[20] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-io/3.5.0/plexus-io-3.5.0.jar
[ERROR] urls[21] = file:/home/build/.m2/repository/org/apache/commons/commons-compress/1.26.2/commons-compress-1.26.2.jar
[ERROR] urls[22] = file:/home/build/.m2/repository/io/airlift/aircompressor/0.27/aircompressor-0.27.jar
[ERROR] urls[23] = file:/home/build/.m2/repository/org/tukaani/xz/1.9/xz-1.9.jar
[ERROR] urls[24] = file:/home/build/.m2/repository/com/github/luben/zstd-jni/1.5.6-3/zstd-jni-1.5.6-3.jar
[ERROR] urls[25] = file:/home/build/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar
[ERROR] urls[26] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar
[ERROR] urls[27] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar
[ERROR] urls[28] = file:/home/build/.m2/repository/org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar
[ERROR] urls[29] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar
[ERROR] urls[30] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar
[ERROR] urls[31] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar
[ERROR] urls[32] = file:/home/build/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar
[ERROR] urls[33] = file:/home/build/.m2/repository/commons-codec/commons-codec/1.11/commons-codec-1.11.jar
[ERROR] urls[34] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar
[ERROR] urls[35] = file:/home/build/.m2/repository/org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar
[ERROR] urls[36] = file:/home/build/.m2/repository/org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------: org.sonatype.plexus.components.sec.dispatcher.SecDispatcher
[ERROR] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT:deploy-to-engine (test.webserver.deploy.app) on project selenium-test: Execution test.webserver.deploy.app of goal com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT:deploy-to-engine failed: A required class was missing while executing com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT:deploy-to-engine: org/sonatype/plexus/components/sec/dispatcher/SecDispatcher
-----------------------------------------------------
realm =    plugin>com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT
strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
urls[0] = file:/home/build/.m2/repository/com/axonivy/ivy/ci/project-build-plugin/10.0.18-SNAPSHOT/project-build-plugin-10.0.18-SNAPSHOT.jar
urls[1] = file:/home/build/.m2/repository/org/apache/maven/shared/maven-filtering/3.4.0/maven-filtering-3.4.0.jar
urls[2] = file:/home/build/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
urls[3] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-utils/3.6.0/plexus-utils-3.6.0.jar
urls[4] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-xml/3.0.1/plexus-xml-3.0.1.jar
urls[5] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.jar
urls[6] = file:/home/build/.m2/repository/org/apache/maven/wagon/wagon-http/3.5.3/wagon-http-3.5.3.jar
urls[7] = file:/home/build/.m2/repository/org/apache/maven/wagon/wagon-http-shared/3.5.3/wagon-http-shared-3.5.3.jar
urls[8] = file:/home/build/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.36/jcl-over-slf4j-1.7.36.jar
urls[9] = file:/home/build/.m2/repository/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar
urls[10] = file:/home/build/.m2/repository/com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar
urls[11] = file:/home/build/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
urls[12] = file:/home/build/.m2/repository/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar
urls[13] = file:/home/build/.m2/repository/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.jar
urls[14] = file:/home/build/.m2/repository/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar
urls[15] = file:/home/build/.m2/repository/org/apache/commons/commons-lang3/3.17.0/commons-lang3-3.17.0.jar
urls[16] = file:/home/build/.m2/repository/commons-io/commons-io/2.19.0/commons-io-2.19.0.jar
urls[17] = file:/home/build/.m2/repository/org/apache/commons/commons-exec/1.5.0/commons-exec-1.5.0.jar
urls[18] = file:/home/build/.m2/repository/net/lingala/zip4j/zip4j/2.11.5/zip4j-2.11.5.jar
urls[19] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-archiver/4.10.0/plexus-archiver-4.10.0.jar
urls[20] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-io/3.5.0/plexus-io-3.5.0.jar
urls[21] = file:/home/build/.m2/repository/org/apache/commons/commons-compress/1.26.2/commons-compress-1.26.2.jar
urls[22] = file:/home/build/.m2/repository/io/airlift/aircompressor/0.27/aircompressor-0.27.jar
urls[23] = file:/home/build/.m2/repository/org/tukaani/xz/1.9/xz-1.9.jar
urls[24] = file:/home/build/.m2/repository/com/github/luben/zstd-jni/1.5.6-3/zstd-jni-1.5.6-3.jar
urls[25] = file:/home/build/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar
urls[26] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar
urls[27] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar
urls[28] = file:/home/build/.m2/repository/org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar
urls[29] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar
urls[30] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar
urls[31] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar
urls[32] = file:/home/build/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar
urls[33] = file:/home/build/.m2/repository/commons-codec/commons-codec/1.11/commons-codec-1.11.jar
urls[34] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar
urls[35] = file:/home/build/.m2/repository/org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar
urls[36] = file:/home/build/.m2/repository/org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.jar
Number of foreign imports: 1
import: Entry[import  from realm ClassRealm[maven.api, parent: null]]

-----------------------------------------------------

    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:375)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution test.webserver.deploy.app of goal com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT:deploy-to-engine failed: A required class was missing while executing com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT:deploy-to-engine: org/sonatype/plexus/components/sec/dispatcher/SecDispatcher
-----------------------------------------------------
realm =    plugin>com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT
strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
urls[0] = file:/home/build/.m2/repository/com/axonivy/ivy/ci/project-build-plugin/10.0.18-SNAPSHOT/project-build-plugin-10.0.18-SNAPSHOT.jar
urls[1] = file:/home/build/.m2/repository/org/apache/maven/shared/maven-filtering/3.4.0/maven-filtering-3.4.0.jar
urls[2] = file:/home/build/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
urls[3] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-utils/3.6.0/plexus-utils-3.6.0.jar
urls[4] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-xml/3.0.1/plexus-xml-3.0.1.jar
urls[5] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.jar
urls[6] = file:/home/build/.m2/repository/org/apache/maven/wagon/wagon-http/3.5.3/wagon-http-3.5.3.jar
urls[7] = file:/home/build/.m2/repository/org/apache/maven/wagon/wagon-http-shared/3.5.3/wagon-http-shared-3.5.3.jar
urls[8] = file:/home/build/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.36/jcl-over-slf4j-1.7.36.jar
urls[9] = file:/home/build/.m2/repository/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar
urls[10] = file:/home/build/.m2/repository/com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar
urls[11] = file:/home/build/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
urls[12] = file:/home/build/.m2/repository/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar
urls[13] = file:/home/build/.m2/repository/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.jar
urls[14] = file:/home/build/.m2/repository/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar
urls[15] = file:/home/build/.m2/repository/org/apache/commons/commons-lang3/3.17.0/commons-lang3-3.17.0.jar
urls[16] = file:/home/build/.m2/repository/commons-io/commons-io/2.19.0/commons-io-2.19.0.jar
urls[17] = file:/home/build/.m2/repository/org/apache/commons/commons-exec/1.5.0/commons-exec-1.5.0.jar
urls[18] = file:/home/build/.m2/repository/net/lingala/zip4j/zip4j/2.11.5/zip4j-2.11.5.jar
urls[19] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-archiver/4.10.0/plexus-archiver-4.10.0.jar
urls[20] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-io/3.5.0/plexus-io-3.5.0.jar
urls[21] = file:/home/build/.m2/repository/org/apache/commons/commons-compress/1.26.2/commons-compress-1.26.2.jar
urls[22] = file:/home/build/.m2/repository/io/airlift/aircompressor/0.27/aircompressor-0.27.jar
urls[23] = file:/home/build/.m2/repository/org/tukaani/xz/1.9/xz-1.9.jar
urls[24] = file:/home/build/.m2/repository/com/github/luben/zstd-jni/1.5.6-3/zstd-jni-1.5.6-3.jar
urls[25] = file:/home/build/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar
urls[26] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar
urls[27] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar
urls[28] = file:/home/build/.m2/repository/org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar
urls[29] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar
urls[30] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar
urls[31] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar
urls[32] = file:/home/build/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar
urls[33] = file:/home/build/.m2/repository/commons-codec/commons-codec/1.11/commons-codec-1.11.jar
urls[34] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar
urls[35] = file:/home/build/.m2/repository/org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar
urls[36] = file:/home/build/.m2/repository/org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.jar
Number of foreign imports: 1
import: Entry[import  from realm ClassRealm[maven.api, parent: null]]

-----------------------------------------------------

    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.PluginContainerException: A required class was missing while executing com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT:deploy-to-engine: org/sonatype/plexus/components/sec/dispatcher/SecDispatcher
-----------------------------------------------------
realm =    plugin>com.axonivy.ivy.ci:project-build-plugin:10.0.18-SNAPSHOT
strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
urls[0] = file:/home/build/.m2/repository/com/axonivy/ivy/ci/project-build-plugin/10.0.18-SNAPSHOT/project-build-plugin-10.0.18-SNAPSHOT.jar
urls[1] = file:/home/build/.m2/repository/org/apache/maven/shared/maven-filtering/3.4.0/maven-filtering-3.4.0.jar
urls[2] = file:/home/build/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
urls[3] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-utils/3.6.0/plexus-utils-3.6.0.jar
urls[4] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-xml/3.0.1/plexus-xml-3.0.1.jar
urls[5] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.jar
urls[6] = file:/home/build/.m2/repository/org/apache/maven/wagon/wagon-http/3.5.3/wagon-http-3.5.3.jar
urls[7] = file:/home/build/.m2/repository/org/apache/maven/wagon/wagon-http-shared/3.5.3/wagon-http-shared-3.5.3.jar
urls[8] = file:/home/build/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.36/jcl-over-slf4j-1.7.36.jar
urls[9] = file:/home/build/.m2/repository/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar
urls[10] = file:/home/build/.m2/repository/com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar
urls[11] = file:/home/build/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
urls[12] = file:/home/build/.m2/repository/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar
urls[13] = file:/home/build/.m2/repository/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.jar
urls[14] = file:/home/build/.m2/repository/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar
urls[15] = file:/home/build/.m2/repository/org/apache/commons/commons-lang3/3.17.0/commons-lang3-3.17.0.jar
urls[16] = file:/home/build/.m2/repository/commons-io/commons-io/2.19.0/commons-io-2.19.0.jar
urls[17] = file:/home/build/.m2/repository/org/apache/commons/commons-exec/1.5.0/commons-exec-1.5.0.jar
urls[18] = file:/home/build/.m2/repository/net/lingala/zip4j/zip4j/2.11.5/zip4j-2.11.5.jar
urls[19] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-archiver/4.10.0/plexus-archiver-4.10.0.jar
urls[20] = file:/home/build/.m2/repository/org/codehaus/plexus/plexus-io/3.5.0/plexus-io-3.5.0.jar
urls[21] = file:/home/build/.m2/repository/org/apache/commons/commons-compress/1.26.2/commons-compress-1.26.2.jar
urls[22] = file:/home/build/.m2/repository/io/airlift/aircompressor/0.27/aircompressor-0.27.jar
urls[23] = file:/home/build/.m2/repository/org/tukaani/xz/1.9/xz-1.9.jar
urls[24] = file:/home/build/.m2/repository/com/github/luben/zstd-jni/1.5.6-3/zstd-jni-1.5.6-3.jar
urls[25] = file:/home/build/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar
urls[26] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar
urls[27] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar
urls[28] = file:/home/build/.m2/repository/org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar
urls[29] = file:/home/build/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar
urls[30] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar
urls[31] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar
urls[32] = file:/home/build/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar
urls[33] = file:/home/build/.m2/repository/commons-codec/commons-codec/1.11/commons-codec-1.11.jar
urls[34] = file:/home/build/.m2/repository/org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar
urls[35] = file:/home/build/.m2/repository/org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar
urls[36] = file:/home/build/.m2/repository/org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.jar
Number of foreign imports: 1
import: Entry[import  from realm ClassRealm[maven.api, parent: null]]

-----------------------------------------------------

    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:169)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.NoClassDefFoundError: org/sonatype/plexus/components/sec/dispatcher/SecDispatcher
    at java.lang.Class.getDeclaredFields0 (Native Method)
    at java.lang.Class.privateGetDeclaredFields (Class.java:3297)
    at java.lang.Class.getDeclaredFields (Class.java:2371)
    at com.google.inject.spi.InjectionPoint.getDeclaredFields (InjectionPoint.java:760)
    at com.google.inject.spi.InjectionPoint.getInjectionPoints (InjectionPoint.java:670)
    at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields (InjectionPoint.java:378)
    at com.google.inject.internal.ConstructorBindingImpl.getInternalDependencies (ConstructorBindingImpl.java:182)
    at com.google.inject.internal.InjectorImpl.getInternalDependencies (InjectorImpl.java:661)
    at com.google.inject.internal.InjectorImpl.cleanup (InjectorImpl.java:617)
    at com.google.inject.internal.InjectorImpl.initializeJitBinding (InjectorImpl.java:603)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBinding (InjectorImpl.java:932)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive (InjectorImpl.java:852)
    at com.google.inject.internal.InjectorImpl.getJustInTimeBinding (InjectorImpl.java:291)
    at com.google.inject.internal.InjectorImpl.getBindingOrThrow (InjectorImpl.java:222)
    at com.google.inject.internal.InjectorImpl.getProviderOrThrow (InjectorImpl.java:1040)
    at com.google.inject.internal.InjectorImpl.getProvider (InjectorImpl.java:1071)
    at com.google.inject.internal.InjectorImpl.getProvider (InjectorImpl.java:1034)
    at com.google.inject.internal.InjectorImpl.getInstance (InjectorImpl.java:1086)
    at org.eclipse.sisu.space.AbstractDeferredClass.get (AbstractDeferredClass.java:48)
    at com.google.inject.internal.ProviderInternalFactory.provision (ProviderInternalFactory.java:85)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision (InternalFactoryToInitializableAdapter.java:57)
    at com.google.inject.internal.ProviderInternalFactory$1.call (ProviderInternalFactory.java:66)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision (ProvisionListenerStackCallback.java:112)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision (ProvisionListenerStackCallback.java:127)
    at com.google.inject.internal.ProvisionListenerStackCallback.provision (ProvisionListenerStackCallback.java:66)
    at com.google.inject.internal.ProviderInternalFactory.circularGet (ProviderInternalFactory.java:61)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.get (InternalFactoryToInitializableAdapter.java:47)
    at com.google.inject.internal.InjectorImpl$1.get (InjectorImpl.java:1050)
    at org.eclipse.sisu.inject.Guice4$1.get (Guice4.java:162)
    at org.eclipse.sisu.inject.LazyBeanEntry.getValue (LazyBeanEntry.java:81)
    at org.eclipse.sisu.plexus.LazyPlexusBean.getValue (LazyPlexusBean.java:51)
    at org.codehaus.plexus.DefaultPlexusContainer.lookup (DefaultPlexusContainer.java:263)
    at org.codehaus.plexus.DefaultPlexusContainer.lookup (DefaultPlexusContainer.java:255)
    at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getConfiguredMojo (DefaultMavenPluginManager.java:520)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:124)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.ClassNotFoundException: org.sonatype.plexus.components.sec.dispatcher.SecDispatcher
    at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass (SelfFirstStrategy.java:50)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass (ClassRealm.java:271)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:247)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:239)
    at java.lang.Class.getDeclaredFields0 (Native Method)
    at java.lang.Class.privateGetDeclaredFields (Class.java:3297)
    at java.lang.Class.getDeclaredFields (Class.java:2371)
    at com.google.inject.spi.InjectionPoint.getDeclaredFields (InjectionPoint.java:760)
    at com.google.inject.spi.InjectionPoint.getInjectionPoints (InjectionPoint.java:670)
    at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields (InjectionPoint.java:378)
    at com.google.inject.internal.ConstructorBindingImpl.getInternalDependencies (ConstructorBindingImpl.java:182)
    at com.google.inject.internal.InjectorImpl.getInternalDependencies (InjectorImpl.java:661)
    at com.google.inject.internal.InjectorImpl.cleanup (InjectorImpl.java:617)
    at com.google.inject.internal.InjectorImpl.initializeJitBinding (InjectorImpl.java:603)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBinding (InjectorImpl.java:932)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive (InjectorImpl.java:852)
    at com.google.inject.internal.InjectorImpl.getJustInTimeBinding (InjectorImpl.java:291)
    at com.google.inject.internal.InjectorImpl.getBindingOrThrow (InjectorImpl.java:222)
    at com.google.inject.internal.InjectorImpl.getProviderOrThrow (InjectorImpl.java:1040)
    at com.google.inject.internal.InjectorImpl.getProvider (InjectorImpl.java:1071)
    at com.google.inject.internal.InjectorImpl.getProvider (InjectorImpl.java:1034)
    at com.google.inject.internal.InjectorImpl.getInstance (InjectorImpl.java:1086)
    at org.eclipse.sisu.space.AbstractDeferredClass.get (AbstractDeferredClass.java:48)
    at com.google.inject.internal.ProviderInternalFactory.provision (ProviderInternalFactory.java:85)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision (InternalFactoryToInitializableAdapter.java:57)
    at com.google.inject.internal.ProviderInternalFactory$1.call (ProviderInternalFactory.java:66)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision (ProvisionListenerStackCallback.java:112)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision (ProvisionListenerStackCallback.java:127)
    at com.google.inject.internal.ProvisionListenerStackCallback.provision (ProvisionListenerStackCallback.java:66)
    at com.google.inject.internal.ProviderInternalFactory.circularGet (ProviderInternalFactory.java:61)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.get (InternalFactoryToInitializableAdapter.java:47)
    at com.google.inject.internal.InjectorImpl$1.get (InjectorImpl.java:1050)
    at org.eclipse.sisu.inject.Guice4$1.get (Guice4.java:162)
    at org.eclipse.sisu.inject.LazyBeanEntry.getValue (LazyBeanEntry.java:81)
    at org.eclipse.sisu.plexus.LazyPlexusBean.getValue (LazyPlexusBean.java:51)
    at org.codehaus.plexus.DefaultPlexusContainer.lookup (DefaultPlexusContainer.java:263)
    at org.codehaus.plexus.DefaultPlexusContainer.lookup (DefaultPlexusContainer.java:255)
    at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getConfiguredMojo (DefaultMavenPluginManager.java:520)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:124)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[ERROR] 
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :selenium-test
```
