### PR TITLE
XIVY-17416 fix out of memory during iar packing

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/IarPackagingMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/IarPackagingMojo.java
@@ -118,7 +118,7 @@ public class IarPackagingMojo extends AbstractMojo {
   }
 
   private void createIvyArchive(File projectDir, Path targetIar) throws MojoExecutionException {
-    ZipArchiver archiver = new ZipArchiver();
+    ZipArchiver archiver = new IvyZipArchiver();
     archiver.setDuplicateBehavior(Archiver.DUPLICATES_SKIP);
     archiver.setDestFile(targetIar.toFile());
     FileSetConverter fsConverter = new FileSetConverter(project.getBasedir().toPath());

--- a/src/main/java/ch/ivyteam/ivy/maven/IvyZipArchiver.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/IvyZipArchiver.java
@@ -1,0 +1,27 @@
+package ch.ivyteam.ivy.maven;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.compress.parallel.InputStreamSupplier;
+import org.codehaus.plexus.archiver.ArchiverException;
+import org.codehaus.plexus.archiver.zip.ConcurrentJarCreator;
+import org.codehaus.plexus.archiver.zip.ZipArchiver;
+
+public class IvyZipArchiver extends ZipArchiver {
+
+  @Override
+  protected void zipFile(
+      InputStreamSupplier is,
+      ConcurrentJarCreator zOut,
+      String vPath,
+      long lastModified,
+      File fromArchive,
+      int mode,
+      String symlinkDestination,
+      boolean addInParallel)
+      throws IOException, ArchiverException {
+    super.zipFile(is, zOut, vPath, lastModified, fromArchive, mode, symlinkDestination, false);
+  }
+
+}


### PR DESCRIPTION
do not add files to zip in parallel. in `zipDir` parallel is still used, but seem not to be a problem

before my sample failed with
```
export MAVEN_OPTS="-Xmx2000m -XX:+HeapDumpOnOutOfMemoryError"
mvn ivy:pack-iar -f AxonIvyPortal/portal/pom.xml -X
```

with this change I can run it with:
```
export MAVEN_OPTS="-Xmx30m -XX:+HeapDumpOnOutOfMemoryError"
mvn ivy:pack-iar -f AxonIvyPortal/portal/pom.xml -X
```

I have not found why jar plugin does not have the same problem, see https://github.com/apache/maven-jar-plugin/blob/master/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java