### PR TITLE
XIVY-17416 fix out of memory during iar packing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.10.1</version>
+      <version>4.9.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
I have left a comment here https://github.com/codehaus-plexus/plexus-archiver/issues/382

they have changed stuff in this concurrent jar creator:
https://github.com/codehaus-plexus/plexus-archiver/compare/plexus-archiver-4.9.2...master