### PR TITLE
Remove maven parameter 'deployTargetFileFormat' - no longer supported by Axon Ivy Engine

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/deploy/AbstractDeployMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/deploy/AbstractDeployMojo.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.ReadOnlyFileSystemException;
 
 import javax.inject.Inject;
 
@@ -119,33 +118,6 @@ public abstract class AbstractDeployMojo extends AbstractIntegrationTestMojo {
    */
   @Parameter(property = "ivy.deploy.target.state", defaultValue = DefaultDeployOptions.STATE_ACTIVE_AND_RELEASED)
   public String deployTargetState;
-
-  /**
-   * The target file format as which the project will be deployed into the
-   * process model version (PMV).
-   *
-   * <ul>
-   * <li><code>AUTO</code>: Keep the format of the origin project file if
-   * possible. Deploys IAR or ZIP projects into a ZIP process model version.
-   * <br>
-   * But if the target PMV already exists as expanded directory, the new version
-   * will be expanded as well.</li>
-   * <li><code>PACKED</code>: Enforce the deployment of a project as zipped
-   * file. Normal (expanded) project directories will be compressed into a ZIP
-   * during deployment.</li>
-   * <li><code>EXPANDED</code>: Enforce the deployment of a project as expanded
-   * file directory.<br>
-   * This is recommended for projects that change the project files at runtime.
-   * E.g. projects that use the Content Management (CMS) write API.<br>
-   * The expanded format behaves exactly like projects deployed with Axon Ivy
-   * 7.0 or older. You might choose to deploy expanded projects in order to
-   * avoid {@link ReadOnlyFileSystemException} at runtime.<br>
-   * <strong>Warning</strong>: Expanded projects will perform slower at runtime
-   * and are therefore not recommended.</li>
-   * </ul>
-   */
-  @Parameter(property = "ivy.deploy.target.file.format", defaultValue = DefaultDeployOptions.FILE_FORMAT_AUTO)
-  public String deployTargetFileFormat;
 
   /**
    * <p>

--- a/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToEngineMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/deploy/DeployToEngineMojo.java
@@ -227,7 +227,6 @@ public class DeployToEngineMojo extends AbstractDeployMojo {
   public interface DefaultDeployOptions {
     String VERSION_AUTO = "AUTO";
     String STATE_ACTIVE_AND_RELEASED = "ACTIVE_AND_RELEASED";
-    String FILE_FORMAT_AUTO = "AUTO";
     String DEPLOY_TEST_USERS = "AUTO";
   }
 

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/YamlOptionsFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/deploy/YamlOptionsFactory.java
@@ -55,8 +55,7 @@ public class YamlOptionsFactory {
   private static void writeTarget(AbstractDeployMojo config, JsonGenerator gen) throws IOException {
     boolean defaultVersion = DefaultDeployOptions.VERSION_AUTO.equals(config.deployTargetVersion);
     boolean defaultState = DefaultDeployOptions.STATE_ACTIVE_AND_RELEASED.equals(config.deployTargetState);
-    boolean defaultFileFormat = DefaultDeployOptions.FILE_FORMAT_AUTO.equals(config.deployTargetFileFormat);
-    if (!defaultVersion || !defaultState || !defaultFileFormat) {
+    if (!defaultVersion || !defaultState) {
       gen.writeObjectFieldStart("target");
       if (!defaultVersion) {
         gen.writeStringField("version", config.deployTargetVersion);
@@ -64,10 +63,6 @@ public class YamlOptionsFactory {
       if (!defaultState) {
         gen.writeStringField("state", config.deployTargetState);
       }
-      if (!defaultFileFormat) {
-        gen.writeStringField("fileFormat", config.deployTargetFileFormat);
-      }
-
       gen.writeEndObject();
     }
   }

--- a/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToEngineMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/deploy/TestDeployToEngineMojo.java
@@ -96,7 +96,6 @@ public class TestDeployToEngineMojo {
     mojo.deployTestUsers = "true";
     mojo.deployTargetVersion = "RELEASED";
     mojo.deployTargetState = "INACTIVE";
-    mojo.deployTargetFileFormat = "EXPANDED";
 
     var deployedIar = getTarget(mojo.deployFile, mojo);
     var deploymentOptionsFile = deployedIar.resolveSibling(deployedIar.getFileName() + ".options.yaml");
@@ -112,8 +111,7 @@ public class TestDeployToEngineMojo {
             deployTestUsers: "TRUE"
             target:
               version: RELEASED
-              state: INACTIVE
-              fileFormat: EXPANDED""");
+              state: INACTIVE""");
       Files.delete(deploymentOptionsFile);
       assertThat(deployedIar).exists();
       Files.delete(deployedIar);

--- a/src/test/java/ch/ivyteam/ivy/maven/engine/deploy/TestYamlOptionsFactory.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/engine/deploy/TestYamlOptionsFactory.java
@@ -18,7 +18,6 @@ class TestYamlOptionsFactory {
     config.deployTestUsers = "true";
     config.deployTargetVersion = "RELEASED";
     config.deployTargetState = "ACTIVE";
-    config.deployTargetFileFormat = "EXPANDED";
 
     String yamlOptions = YamlOptionsFactory.toYaml(config);
     assertThat(yamlOptions).isEqualTo(getFileContent("allOptionsSet.yaml"));
@@ -36,7 +35,6 @@ class TestYamlOptionsFactory {
     config.deployTestUsers = DefaultDeployOptions.DEPLOY_TEST_USERS;
     config.deployTargetVersion = DefaultDeployOptions.VERSION_AUTO;
     config.deployTargetState = DefaultDeployOptions.STATE_ACTIVE_AND_RELEASED;
-    config.deployTargetFileFormat = DefaultDeployOptions.FILE_FORMAT_AUTO;
 
     String yamlOptions = YamlOptionsFactory.toYaml(config);
     assertThat(yamlOptions).isNullOrEmpty();

--- a/src/test/resources/ch/ivyteam/ivy/maven/engine/deploy/allOptionsSet.yaml
+++ b/src/test/resources/ch/ivyteam/ivy/maven/engine/deploy/allOptionsSet.yaml
@@ -2,4 +2,3 @@ deployTestUsers: "TRUE"
 target:
   version: RELEASED
   state: ACTIVE
-  fileFormat: EXPANDED


### PR DESCRIPTION
This has already been dropped in the Engine and in the Engine Cockpit.
