### PR TITLE
Deprecate goal share-engine-core-classpath

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/ShareEngineCoreClasspathMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/ShareEngineCoreClasspathMojo.java
@@ -16,7 +16,12 @@
 
 package ch.ivyteam.ivy.maven;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -26,7 +31,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory;
+import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory.OsgiDir;
 import ch.ivyteam.ivy.maven.util.MavenProperties;
 
 /**
@@ -34,22 +39,58 @@ import ch.ivyteam.ivy.maven.util.MavenProperties;
  * <code>ivy.engine.core.classpath</code>.
  *
  * @since 6.2.0
+ * @deprecated Sharing the classpath of the Axon Ivy Engine is no longer needed, because all
+ *             dependencies are available as Maven dependencies.
  */
+@Deprecated(since = "14.0.0")
 @Mojo(name = ShareEngineCoreClasspathMojo.GOAL)
 public class ShareEngineCoreClasspathMojo extends AbstractEngineMojo {
 
+  private static final List<String> ENGINE_LIB_DIRECTORIES = Arrays.asList(
+      OsgiDir.INSTALL_AREA + "/" + OsgiDir.LIB_BOOT,
+      OsgiDir.PLUGINS,
+      OsgiDir.INSTALL_AREA + "/configuration/org.eclipse.osgi", // unpacked jars from OSGI bundles
+      "webapps" + File.separator + "ivy" + File.separator + "WEB-INF" + File.separator + "lib");
+
+  @Deprecated
   public static final String GOAL = "share-engine-core-classpath";
 
+  @Deprecated
   public static final String IVY_ENGINE_CORE_CLASSPATH_PROPERTY = "ivy.engine.core.classpath";
 
+  @Deprecated
   @Parameter(property = "project", required = true, readonly = true)
   MavenProject project;
 
+  @Deprecated
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    List<Path> ivyEngineClassPathFiles = EngineClassLoaderFactory.getIvyEngineClassPathFiles(identifyAndGetEngineDirectory());
+    List<Path> ivyEngineClassPathFiles = getIvyEngineClassPathFiles(identifyAndGetEngineDirectory());
     String propertyValue = StringUtils.join(ivyEngineClassPathFiles, ",");
     MavenProperties properties = new MavenProperties(project, getLog());
     properties.setMavenProperty(IVY_ENGINE_CORE_CLASSPATH_PROPERTY, propertyValue);
+  }
+
+  private static List<Path> getIvyEngineClassPathFiles(Path engineDirectory) {
+    if (engineDirectory == null) {
+      return List.of();
+    }
+
+    var classPathFiles = new ArrayList<Path>();
+    for (String libDirPath : ENGINE_LIB_DIRECTORIES) {
+      var jarDir = engineDirectory.resolve(libDirPath);
+      if (!Files.isDirectory(jarDir)) {
+        continue;
+      }
+      try (var walker = Files.walk(jarDir)) {
+        var jars = walker
+            .filter(p -> p.getFileName().toString().endsWith(".jar"))
+            .toList();
+        classPathFiles.addAll(jars);
+      } catch (IOException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+    return classPathFiles;
   }
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/compile/ValidateProjectMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/ValidateProjectMojo.java
@@ -65,7 +65,7 @@ public class ValidateProjectMojo extends AbstractMojo {
     getLog().info("Validation finished in " + duration + "ms");
   }
 
-  private List<ProjectValidator> validators() {
+  private List<ProjectValidator<?>> validators() {
     return List.of(
         new UserProjectValidator(),
         new RoleProjectValidator(),

--- a/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/engine/EngineClassLoaderFactory.java
@@ -16,13 +16,11 @@
 
 package ch.ivyteam.ivy.maven.engine;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -40,15 +38,6 @@ public class EngineClassLoaderFactory {
     String PLUGINS = INSTALL_AREA + "/plugins";
     String LIB_BOOT = "lib/boot";
   }
-
-  private static final List<String> ENGINE_LIB_DIRECTORIES = Arrays.asList(
-      OsgiDir.INSTALL_AREA + "/" + OsgiDir.LIB_BOOT,
-      OsgiDir.PLUGINS,
-      OsgiDir.INSTALL_AREA + "/configuration/org.eclipse.osgi", // unpacked
-                                                                // jars from
-                                                                // OSGI
-                                                                // bundles
-      "webapps" + File.separator + "ivy" + File.separator + "WEB-INF" + File.separator + "lib");
 
   public static List<Path> getOsgiBootstrapClasspath(Path engineDirectory) {
     if (engineDirectory == null || !Files.isDirectory(engineDirectory)) {
@@ -71,28 +60,5 @@ public class EngineClassLoaderFactory {
         throw new RuntimeException(ex);
       }
     }
-  }
-
-  public static List<Path> getIvyEngineClassPathFiles(Path engineDirectory) {
-    if (engineDirectory == null) {
-      return List.of();
-    }
-
-    var classPathFiles = new ArrayList<Path>();
-    for (String libDirPath : ENGINE_LIB_DIRECTORIES) {
-      var jarDir = engineDirectory.resolve(libDirPath);
-      if (!Files.isDirectory(jarDir)) {
-        continue;
-      }
-      try (var walker = Files.walk(jarDir)) {
-        var jars = walker
-            .filter(p -> p.getFileName().toString().endsWith(".jar"))
-            .toList();
-        classPathFiles.addAll(jars);
-      } catch (IOException ex) {
-        throw new RuntimeException(ex);
-      }
-    }
-    return classPathFiles;
   }
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/TestShareEngineClasspathMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/TestShareEngineClasspathMojo.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import ch.ivyteam.ivy.maven.engine.EngineClassLoaderFactory.OsgiDir;
 
 @MojoTest
+@SuppressWarnings("deprecation")
 class TestShareEngineClasspathMojo {
 
   private ShareEngineCoreClasspathMojo mojo;


### PR DESCRIPTION
I would already remove it, but portal is using it to generate javadoc and I'm not able to easily remove it there. Because I'm not able to execute the build locally to build the javadoc.

But now, they get a hint that they need to remove it :)