### PR TITLE
Allow Sprint-Qualified releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,9 @@ pipeline {
     string(name: 'engineListUrl',
       description: 'Engine to use for build',
       defaultValue: 'https://product.ivyteam.io')
+    string(name: 'sprintQualifier',
+      description: "Optional sprint qualifier (e.g. m7 for Sprint 7). Empty keeps the original project version.",
+      defaultValue: '')
   }
 
   stages {
@@ -23,6 +26,10 @@ pipeline {
         script {
           setupGPGEnvironment()
           withCredentials([string(credentialsId: 'gpg.password', variable: 'GPG_PWD')]) {
+            def qualifier = params.sprintQualifier?.trim()
+            if (qualifier) {
+              applyVersionQualifier(qualifier)
+            }
             def phase = isReleasingBranch() ? 'deploy' : 'verify'
             maven cmd: "clean ${phase} " +
               "-Dgpg.skip=false " +
@@ -167,4 +174,11 @@ def collectBuildArtifacts()  {
     excludeType('cyclonedx:makeBom')
   ]
   recordIssues tools: [java()], qualityGates: [[threshold: 1, type: 'TOTAL']]
+}
+
+def applyVersionQualifier(String qualifier) {
+  def currentVersion = sh(script: "mvn help:evaluate -Dexpression=project.version -q -DforceStdout", returnStdout: true).trim()
+  def qualified  = currentVersion.replaceFirst(/-SNAPSHOT$/, "-${qualifier}")
+  echo "Using version '${qualified}' for this build."
+  maven cmd: "versions:set -DnewVersion=${qualified} -DgenerateBackupPoms=false"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,7 @@
         <configuration>
           <outputFormat>json</outputFormat>
           <includeLicenseText>true</includeLicenseText>
+          <skipNotDeployed>false</skipNotDeployed>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
enable project-build-plugin sprint releases (still a manual task)
https://github.com/axonivy/core/pull/13375

example ruN:
https://jenkins.ivyteam.io/job/project-build-plugin/job/sprint.release/