### PR TITLE
XIVY-19237 Enhance ValidateProjectMojo configurability

### DIFF
--- a/src/main/java/ch/ivyteam/ivy/maven/compile/ValidateProjectMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/ValidateProjectMojo.java
@@ -3,6 +3,7 @@ package ch.ivyteam.ivy.maven.compile;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
@@ -26,18 +27,67 @@ import ch.ivyteam.ivy.project.validation.ProjectValidatorContext;
 import ch.ivyteam.ivy.project.validation.ProjectValidatorResult.Message;
 
 /**
- * Validates an ivy Project with an ivyEngine.
+ * Validates an ivy Project.
  */
 @Mojo(name = ValidateProjectMojo.GOAL, requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
 public class ValidateProjectMojo extends AbstractMojo {
   public static final String GOAL = "validateProject";
+
+  /**
+   * Set to <code>true</code> to completely skip the project validation.
+   * @since 14.0.0
+   */
+  @Parameter(property = "ivy.validation.skip", defaultValue = "false")
+  boolean skipProjectValidation;
+
   /**
    * Set to <code>false</code> to perform the validation of ivyScript code
    * within ivy processes.
+   *
+   * @deprecated use {@link #skipProjectValidation} (property <code>ivy.validation.skip</code>)
+   *             instead, which skips the validation entirely rather than
+   *             just the script validation part. This parameter will be
+   *             removed in a future version.
    * @since 8.0.3
    */
+  @Deprecated(since = "14.0.0", forRemoval = true)
   @Parameter(property = "ivy.script.validation.skip", defaultValue = "false")
   boolean skipScriptValidation;
+
+  /**
+   * List of validators to deliberately exclude from the validation run.
+   * The following are currently included:
+   * <ul>
+   * <li><code>role</code></li>
+   * <li><code>database</code></li>
+   * <li><code>form</code></li>
+   * <li><code>dataclass</code></li>
+   * <li><code>process</code></li>
+   * <li><code>restclient</code></li>
+   * <li><code>webserviceclient</code></li>
+   * <li><code>variable</code></li>
+   * <li><code>user</code></li>
+   * </ul>
+   *
+   * Configure a fixed set in the POM:
+   * <pre>
+   * &lt;configuration&gt;
+   * &lt;excludeValidators&gt;
+   * &lt;validator&gt;process&lt;/validator&gt;
+   * &lt;validator&gt;role&lt;/validator&gt;
+   * &lt;/excludeValidators&gt;
+   * &lt;/configuration&gt;
+   * </pre>
+   *
+   * Or set it directly from the command line as a comma-separated list,
+   * without touching the POM:
+   * <pre>
+   * mvn install -Divy.validation.excludeValidators=role,webservice
+   * </pre>
+   * @since 14.0.0
+   */
+  @Parameter(property = "ivy.validation.excludeValidators")
+  List<String> excludeValidators;
 
   @Parameter(property = "project", required = true, readonly = true)
   MavenProject project;
@@ -47,11 +97,20 @@ public class ValidateProjectMojo extends AbstractMojo {
 
   @Override
   public void execute() {
-    if (skipScriptValidation) {
-      getLog().info("Skipping ivy script validation");
+    if (isSkip()) {
+      getLog().info("Skipping ivy project validation");
       return;
     }
     validateProject();
+  }
+
+  private boolean isSkip() {
+    if (skipScriptValidation) {
+      getLog().warn("The parameter 'ivy.script.validation.skip' is deprecated and will be removed "
+          + "in a future version. Use 'ivy.validation.skip' instead.");
+      return true;
+    }
+    return skipProjectValidation;
   }
 
   private void validateProject() {
@@ -62,7 +121,7 @@ public class ValidateProjectMojo extends AbstractMojo {
       getLog().error("Project is outdated (version: " + version + "). Convert the project to the latest version.");
       return;
     }
-    for (var validator : ProjectValidator.all()) {
+    for (var validator : validators()) {
       var result = validator.validate(ctx);
       for (var message : result.messages()) {
         log(message);
@@ -70,6 +129,37 @@ public class ValidateProjectMojo extends AbstractMojo {
     }
     var duration = System.currentTimeMillis() - time;
     getLog().info("Validation finished in " + duration + "ms");
+  }
+
+  @SuppressWarnings("rawtypes")
+  private List<ProjectValidator> validators() {
+    var excluded = excludedKeywords();
+    if (excluded.isEmpty()) {
+      return ProjectValidator.all();
+    }
+    return ProjectValidator.all().stream()
+        .filter(validator -> !isExcluded(validator, excluded))
+        .toList();
+  }
+
+  private List<String> excludedKeywords() {
+    var keywords = new ArrayList<String>();
+    if (excludeValidators != null) {
+      keywords.addAll(excludeValidators);
+    }
+    return keywords;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private boolean isExcluded(ProjectValidator validator, List<String> excluded) {
+    var id = validator.id();
+    var isExcluded = excluded.stream()
+        .filter(keyword -> keyword != null && !keyword.isBlank())
+        .anyMatch(keyword -> id.equalsIgnoreCase(keyword));
+    if (isExcluded) {
+      getLog().info("Skipping validator '" + validator.id() + "' (excluded by configuration)");
+    }
+    return isExcluded;
   }
 
   private void log(Message message) {

--- a/src/test/java/ch/ivyteam/ivy/maven/compile/TestValidateProjectMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/compile/TestValidateProjectMojo.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 
 import org.apache.maven.api.plugin.testing.InjectMojo;
 import org.apache.maven.api.plugin.testing.MojoTest;
@@ -67,4 +68,59 @@ class TestValidateProjectMojo {
     assertThat(log.getErrors().toString())
         .contains("Project is outdated (version: 140013). Convert the project to the latest version.");
   }
+
+  @Test
+  void skip_completelySkipsValidation() {
+    mojo.skipProjectValidation = true;
+    var log = new LogCollector();
+    mojo.setLog(log);
+    mojo.execute();
+
+    assertThat(log.getInfos().toString()).contains("Skipping ivy project validation");
+    assertThat(log.getErrors()).isEmpty();
+    assertThat(log.getWarnings()).isEmpty();
+  }
+
+  @SuppressWarnings("removal")
+  @Test
+  void deprecatedSkipScriptValidation_stillSkipsEntireValidation() {
+    mojo.skipScriptValidation = true;
+    var log = new LogCollector();
+    mojo.setLog(log);
+    mojo.execute();
+
+    assertThat(log.getWarnings().toString())
+        .contains("The parameter 'ivy.script.validation.skip' is deprecated");
+    assertThat(log.getInfos().toString()).contains("Skipping ivy project validation");
+    assertThat(log.getErrors()).isEmpty();
+  }
+
+  @Test
+  void excludedValidators_excludesConfiguredValidatorByKeyword() {
+    mojo.excludeValidators = List.of("Role");
+    var log = new LogCollector();
+    mojo.setLog(log);
+    mojo.execute();
+
+    assertThat(log.getInfos().toString())
+        .contains("Skipping validator 'role' (excluded by configuration)");
+    assertThat(log.getErrors().toString())
+        .doesNotContain("Role 'HR Manager' has an unknown parent 'Manager'.")
+        // other validators still run
+        .contains("config/variables.yaml: Variable 'Test' is defined multiple times in variables.yaml.");
+  }
+
+  @Test
+  void excludedValidators_isCaseInsensitiveAndMatchesSimpleName() {
+    mojo.excludeValidators = List.of("role", "webServiceClient");
+    var log = new LogCollector();
+    mojo.setLog(log);
+    mojo.execute();
+
+    assertThat(log.getErrors().toString())
+        .doesNotContain("Role 'HR Manager' has an unknown parent 'Manager'.");
+    assertThat(log.getWarnings().toString())
+        .doesNotContain("config/webservice-clients.yaml: The web service client key 'test.name' should be sanitized to 'testname' to avoid potential issues. Use the name for a better readability.");
+  }
+
 }

--- a/src/test/java/ch/ivyteam/ivy/maven/extension/ProjectExtension.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/extension/ProjectExtension.java
@@ -5,6 +5,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.Properties;
 
 import org.apache.commons.lang3.SystemUtils;
@@ -28,7 +29,6 @@ public class ProjectExtension implements BeforeAllCallback, AfterAllCallback, Be
 
   private static Path project;
   private static Path workspace;
-  private static int count = 0;
 
   private Path userDir;
 
@@ -44,12 +44,8 @@ public class ProjectExtension implements BeforeAllCallback, AfterAllCallback, Be
   public void beforeAll(ExtensionContext context) throws Exception {
     this.userDir = SystemUtils.getUserDirPath();
     workspace = Files.createTempDirectory("copySpace");
-    nextProject(context);
-  }
-
-  private void nextProject(ExtensionContext context) {
-    count++;
-    project = workspace.resolve("base_" + context.getDisplayName() + count);
+    project = workspace.resolve("base_" + context.getDisplayName());
+    Files.createDirectories(project);
     System.setProperty("basedir", project.toString());
   }
 
@@ -60,13 +56,13 @@ public class ProjectExtension implements BeforeAllCallback, AfterAllCallback, Be
 
   @Override
   public void beforeEach(ExtensionContext context) throws Exception {
+    clearDirectory(project);
     copyDirectory(userDir.resolve(testBase), project);
   }
 
   @Override
   public void afterEach(ExtensionContext context) throws Exception {
-    PathUtils.delete(project);
-    nextProject(context);
+    clearDirectory(project);
   }
 
   public static MavenProject project() throws IOException {
@@ -116,6 +112,25 @@ public class ProjectExtension implements BeforeAllCallback, AfterAllCallback, Be
           throw new UncheckedIOException(ex);
         }
       });
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  private static void clearDirectory(Path dir) {
+    if (!Files.exists(dir)) {
+      return;
+    }
+    try (var walker = Files.walk(dir)) {
+      walker.sorted(Comparator.reverseOrder())
+          .filter(p -> !p.equals(dir))
+          .forEach(p -> {
+            try {
+              Files.delete(p);
+            } catch (IOException ex) {
+              throw new UncheckedIOException(ex);
+            }
+          });
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);
     }


### PR DESCRIPTION
- Deprecate the skipScriptValidation flag.
- Introduce the skipProjectValidation flag to skip the entire ValidateProjectMojo execution.
- Add a configuration option to exclude specific validators from execution. Validators can be excluded either:
 - via the command line, for example: mvn install -Divy.validation.excludedValidators=Process,Role
 - or via the POM configuration:
```
    <configuration>
      <excludedValidators>
        <excludedValidator>Process</excludedValidator>
        <excludedValidator>Role</excludedValidator>
      </excludedValidators>
    </configuration>
```

- Add tests
- Improve the ProjectExtension so that the same instance can be reused across multiple tests without the tests affecting each other.