### PR TITLE
XIVY-19234 Add ivy-api dependency to validation test projects

### DIFF
--- a/integration-tests/project-validation/a-project/pom.xml
+++ b/integration-tests/project-validation/a-project/pom.xml
@@ -13,7 +13,10 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <dependencies>
-
+    <dependency>
+      <groupId>com.axonivy.ivy.api</groupId>
+      <artifactId>ivy-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.axonivy.validation</groupId>
       <artifactId>b.project</artifactId>

--- a/integration-tests/project-validation/b-project/pom.xml
+++ b/integration-tests/project-validation/b-project/pom.xml
@@ -12,6 +12,12 @@
   <artifactId>b.project</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.axonivy.ivy.api</groupId>
+      <artifactId>ivy-api</artifactId>
+    </dependency>
+  </dependencies>
   <repositories>
     <repository>
       <snapshots>

--- a/integration-tests/project-validation/c-project/pom.xml
+++ b/integration-tests/project-validation/c-project/pom.xml
@@ -13,7 +13,10 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <dependencies>
-
+    <dependency>
+      <groupId>com.axonivy.ivy.api</groupId>
+      <artifactId>ivy-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.axonivy.validation</groupId>
       <artifactId>main.project</artifactId>

--- a/integration-tests/project-validation/d-project/pom.xml
+++ b/integration-tests/project-validation/d-project/pom.xml
@@ -13,7 +13,10 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <dependencies>
-
+    <dependency>
+      <groupId>com.axonivy.ivy.api</groupId>
+      <artifactId>ivy-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.axonivy.validation</groupId>
       <artifactId>c.project</artifactId>

--- a/integration-tests/project-validation/main-project/pom.xml
+++ b/integration-tests/project-validation/main-project/pom.xml
@@ -13,7 +13,10 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <dependencies>
-
+    <dependency>
+      <groupId>com.axonivy.ivy.api</groupId>
+      <artifactId>ivy-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.axonivy.validation</groupId>
       <artifactId>a.project</artifactId>

--- a/integration-tests/project-validation/standalone-project/pom.xml
+++ b/integration-tests/project-validation/standalone-project/pom.xml
@@ -12,6 +12,12 @@
   <artifactId>standalone.project</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.axonivy.ivy.api</groupId>
+      <artifactId>ivy-api</artifactId>
+    </dependency>
+  </dependencies>
   <repositories>
     <repository>
       <snapshots>


### PR DESCRIPTION
- The URLClassLoader built for Project Validation only included resolved Maven artifacts. Without a dependency on ivy-api, no artifacts were resolved, so IvySysClasses (e.g. ch.ivyteam.ivy.scripting.objects.Date) could not be found on the classpath, causing validation to fail.
- Adding ivy-api as a dependency ensures the required engine classes are present on the classpath used for validation.