### PR TITLE
XIVY-19238 Improve project validation summary reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,8 +51,9 @@ pipeline {
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'd.project'.
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'standalone.project'.
               [ERROR] config/webservice-clients.yaml [test]: The web service client key 'test' is not unique, it exists too in a not dependent project 'standalone.project'.
-              [INFO] ------------------------------------------------------------------------
-              [INFO] Project validation summary: b.project
+              [INFO] Project validation finished with 2 files with findings
+              [ERROR] ------------------------------------------------------------------------
+              [ERROR] Project validation summary: b.project
 
               '''.stripIndent().trim(),
               '''
@@ -62,8 +63,9 @@ pipeline {
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'd.project'.
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'standalone.project'.
               [ERROR] config/webservice-clients.yaml [test]: The web service client key 'test' is not unique, it exists too in a not dependent project 'standalone.project'.
-              [INFO] ------------------------------------------------------------------------
-              [INFO] Project validation summary: a.project
+              [INFO] Project validation finished with 2 files with findings
+              [ERROR] ------------------------------------------------------------------------
+              [ERROR] Project validation summary: a.project
               '''.stripIndent().trim(),
               '''
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'a.project'.
@@ -72,8 +74,9 @@ pipeline {
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'd.project'.
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'standalone.project'.
               [ERROR] config/webservice-clients.yaml [test]: The web service client key 'test' is not unique, it exists too in a not dependent project 'standalone.project'.
-              [INFO] ------------------------------------------------------------------------
-              [INFO] Project validation summary: main.project
+              [INFO] Project validation finished with 2 files with findings
+              [ERROR] ------------------------------------------------------------------------
+              [ERROR] Project validation summary: main.project
               '''.stripIndent().trim(),
               '''
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'main.project'.
@@ -82,8 +85,9 @@ pipeline {
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'd.project'.
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'standalone.project'.
               [ERROR] config/webservice-clients.yaml [test]: The web service client key 'test' is not unique, it exists too in a not dependent project 'standalone.project'.
-              [INFO] ------------------------------------------------------------------------
-              [INFO] Project validation summary: c.project
+              [INFO] Project validation finished with 2 files with findings
+              [ERROR] ------------------------------------------------------------------------
+              [ERROR] Project validation summary: c.project
               '''.stripIndent().trim(),
               '''
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'main.project'.
@@ -92,8 +96,9 @@ pipeline {
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'c.project'.
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'standalone.project'.
               [ERROR] config/webservice-clients.yaml [test]: The web service client key 'test' is not unique, it exists too in a not dependent project 'standalone.project'.
-              [INFO] ------------------------------------------------------------------------
-              [INFO] Project validation summary: d.project
+              [INFO] Project validation finished with 2 files with findings
+              [ERROR] ------------------------------------------------------------------------
+              [ERROR] Project validation summary: d.project
               '''.stripIndent().trim(),
               '''
               [WARNING] config/users.yaml [Alex]: User 'Alex' is also defined in project 'main.project'.
@@ -106,8 +111,9 @@ pipeline {
               [ERROR] config/webservice-clients.yaml [test]: The web service client key 'test' is not unique, it exists too in a not dependent project 'b.project'.
               [ERROR] config/webservice-clients.yaml [test]: The web service client key 'test' is not unique, it exists too in a not dependent project 'c.project'.
               [ERROR] config/webservice-clients.yaml [test]: The web service client key 'test' is not unique, it exists too in a not dependent project 'd.project'.
-              [INFO] ------------------------------------------------------------------------
-              [INFO] Project validation summary: standalone.project
+              [INFO] Project validation finished with 2 files with findings
+              [ERROR] ------------------------------------------------------------------------
+              [ERROR] Project validation summary: standalone.project
               '''.stripIndent().trim()
             ]
 

--- a/src/main/java/ch/ivyteam/ivy/maven/compile/ValidateProjectMojo.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/ValidateProjectMojo.java
@@ -109,17 +109,14 @@ public class ValidateProjectMojo extends AbstractMojo {
       return;
     }
 
+    var filter = new ValidatorFilter(excludeValidators, getLog());
+    var validators = filter.apply(ProjectValidator.all());
+
     var reporter = new ValidationReporter(getLog(), project);
-    for (var validator : validatorsToRun()) {
+    for (var validator : validators) {
       validator.validate(ctx).messages().forEach(reporter::report);
     }
-    reporter.logSummary(project.getName(), System.currentTimeMillis() - start);
-  }
-
-  @SuppressWarnings("rawtypes")
-  private List<ProjectValidator> validatorsToRun() {
-    var filter = new ValidatorFilter(excludeValidators, getLog());
-    return filter.apply(ProjectValidator.all());
+    reporter.logSummary(project.getName(), System.currentTimeMillis() - start, filter.skipped());
   }
 
 }

--- a/src/main/java/ch/ivyteam/ivy/maven/compile/ValidationReporter.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/ValidationReporter.java
@@ -2,7 +2,11 @@ package ch.ivyteam.ivy.maven.compile;
 
 import java.net.URI;
 import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
@@ -17,6 +21,7 @@ class ValidationReporter {
   private final Log log;
   private final URI basedir;
   private final Map<Severity, Integer> counts = new EnumMap<>(Severity.class);
+  private final Set<URI> filesWithMessages = new HashSet<>();
 
   ValidationReporter(Log log, MavenProject project) {
     this.log = log;
@@ -31,18 +36,52 @@ class ValidationReporter {
       case INFO -> log.info(line);
     }
     counts.merge(message.severity(), 1, Integer::sum);
+    if (message.file() != null) {
+      filesWithMessages.add(message.file());
+    }
   }
 
-  void logSummary(String projectName, long durationMs) {
-    log.info(RULE);
-    log.info("Project validation summary: " + projectName);
-    log.info(RULE);
-    log.info("  Errors:    " + count(Severity.ERROR));
-    log.info("  Warnings:  " + count(Severity.WARN));
-    log.info("  Info:      " + count(Severity.INFO));
-    log.info("  Total:     " + total());
-    log.info("  Duration:  " + durationMs + " ms");
-    log.info(RULE);
+  void logSummary(String projectName, long durationMs, List<String> skippedValidators) {
+    log.info("Project validation finished with " + findingsSummary());
+    var logger = summaryLogger();
+    logger.accept(RULE);
+    logger.accept("Project validation summary: " + projectName);
+    logger.accept(RULE);
+    logger.accept("  Errors:    " + count(Severity.ERROR));
+    logger.accept("  Warnings:  " + count(Severity.WARN));
+    logger.accept("  Info:      " + count(Severity.INFO));
+    logger.accept("  Total:     " + total());
+    logger.accept("  Duration:  " + durationMs + " ms");
+    logSkipped(logger, skippedValidators);
+    logger.accept(RULE);
+  }
+
+  private String findingsSummary() {
+    if (total() == 0) {
+      return "no issues";
+    }
+    var fileCount = filesWithMessages.size();
+    return fileCount + " file" + (fileCount > 1 ? "s" : "") + " with findings";
+  }
+
+  private void logSkipped(Consumer<CharSequence> logger, List<String> skippedValidators) {
+    if (skippedValidators == null || skippedValidators.isEmpty()) {
+      return;
+    }
+    logger.accept("  Skipped validators (" + skippedValidators.size() + "):");
+    for (var id : skippedValidators) {
+      logger.accept("    - " + id);
+    }
+  }
+
+  private Consumer<CharSequence> summaryLogger() {
+    if (count(Severity.ERROR) > 0) {
+      return log::error;
+    }
+    if (count(Severity.WARN) > 0) {
+      return log::warn;
+    }
+    return log::info;
   }
 
   boolean hasErrors() {

--- a/src/main/java/ch/ivyteam/ivy/maven/compile/ValidatorFilter.java
+++ b/src/main/java/ch/ivyteam/ivy/maven/compile/ValidatorFilter.java
@@ -1,5 +1,6 @@
 package ch.ivyteam.ivy.maven.compile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.plugin.logging.Log;
@@ -9,6 +10,7 @@ import ch.ivyteam.ivy.project.validation.ProjectValidator;
 class ValidatorFilter {
 
   private final List<String> excludeKeywords;
+  private final List<String> skipped = new ArrayList<>();
   private final Log log;
 
   ValidatorFilter(List<String> excludeKeywords, Log log) {
@@ -26,6 +28,10 @@ class ValidatorFilter {
         .toList();
   }
 
+  List<String> skipped() {
+    return List.copyOf(skipped);
+  }
+
   @SuppressWarnings("rawtypes")
   private boolean isExcluded(ProjectValidator validator) {
     var id = validator.id();
@@ -33,6 +39,7 @@ class ValidatorFilter {
         .filter(keyword -> keyword != null && !keyword.isBlank())
         .anyMatch(keyword -> id.equalsIgnoreCase(keyword));
     if (excluded) {
+      skipped.add(id);
       log.info("Skipping validator '" + id + "' (excluded by configuration)");
     }
     return excluded;

--- a/src/test/java/ch/ivyteam/ivy/maven/compile/TestValidateProjectMojo.java
+++ b/src/test/java/ch/ivyteam/ivy/maven/compile/TestValidateProjectMojo.java
@@ -123,4 +123,85 @@ class TestValidateProjectMojo {
         .doesNotContain("config/webservice-clients.yaml [test.name]: The web service client key 'test.name' should be sanitized to 'testname' to avoid potential issues. Use the name for a better readability.");
   }
 
+  @Test
+  void summary_logsAtErrorLevel_whenErrorsArePresent() {
+    var log = new LogCollector();
+    mojo.setLog(log);
+    mojo.execute();
+
+    assertThat(log.getErrors().toString())
+        .contains("Project validation summary")
+        .contains("Errors:    ")
+        .contains("Warnings:  6")
+        .contains("Info:      0")
+        .contains("Total:     ");
+    assertThat(log.getWarnings().toString()).doesNotContain("Project validation summary");
+    assertThat(log.getInfos().toString()).doesNotContain("Project validation summary");
+  }
+
+  @Test
+  void summary_logsAtWarnLevel_whenOnlyWarningsArePresent() {
+    mojo.excludeValidators = List.of("role", "variable", "dataclass", "process", "form", "database");
+    var log = new LogCollector();
+    mojo.setLog(log);
+    mojo.execute();
+
+    assertThat(log.getErrors()).isEmpty();
+    assertThat(log.getWarnings().toString())
+        .contains("Project validation summary")
+        .contains("Errors:    0")
+        .contains("Warnings:  5")
+        .contains("Skipped validators (6):");
+    assertThat(log.getInfos().toString()).doesNotContain("Project validation summary");
+  }
+
+  @Test
+  void summary_logsAtInfoLevel_whenNoErrorsOrWarningsArePresent() {
+    mojo.excludeValidators = List.of(
+        "role", "database", "form", "dataclass", "process",
+        "restclient", "webserviceclient", "variable", "user");
+    var log = new LogCollector();
+    mojo.setLog(log);
+    mojo.execute();
+
+    assertThat(log.getErrors()).isEmpty();
+    assertThat(log.getWarnings()).isEmpty();
+    assertThat(log.getInfos().toString())
+        .contains("Project validation finished with no issues")
+        .contains("Project validation summary")
+        .contains("Errors:    0")
+        .contains("Warnings:  0")
+        .contains("Total:     0")
+        .contains("Skipped validators (9):")
+        .contains("- role")
+        .contains("- database")
+        .contains("- form")
+        .contains("- dataclass")
+        .contains("- process")
+        .contains("- restclient")
+        .contains("- webserviceclient")
+        .contains("- variable")
+        .contains("- user");
+  }
+
+  @Test
+  void summary_isPrecededByPlainInfoLine_soJenkinsDoesNotMisattributeTheFailure() {
+    var log = new LogCollector();
+    mojo.setLog(log);
+    mojo.execute();
+
+    assertThat(log.getInfos().toString())
+        .contains("Project validation finished with")
+        .contains("files with findings");
+  }
+
+  @Test
+  void summary_doesNotListSkippedValidators_whenNoneAreExcluded() {
+    var log = new LogCollector();
+    mojo.setLog(log);
+    mojo.execute();
+
+    assertThat(log.getErrors().toString()).doesNotContain("Skipped validators");
+  }
+
 }


### PR DESCRIPTION
- Log the summary block at the highest severity level found among the reported messages (error > warn > info), instead of always logging it at info level
- List the skipped validators (from excludeValidators) as part of the summary, instead of logging them individually up front

<img width="1938" height="614" alt="grafik" src="https://github.com/user-attachments/assets/b48d85ff-b65b-4c71-a33c-9dbcdfbd4189" />
